### PR TITLE
Update for golang 1.24, simplify atomic primatives

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,44 +1,42 @@
-# This workflow will build a golang project
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
-
 name: Go
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
+
+permissions:
+  contents: read
+
+env:
+  GOCACHE: "/tmp/go-cache"
+  GOMODCACHE: "/tmp/go-mod-cache"
 
 jobs:
-
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - uses: actions/cache@v4
-      with:
-        path: |
-          ~/.cache/go-build
-          ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+          cache-dependency-path: go.sum
 
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: '1.23.x'
-        cache: false
-    
-    - name: Display Go version
-      run: go version
-    
-    - name: go mod tidy (fails if changes are needed)
-      run: go mod tidy --diff
+      - name: Display Go version
+        run: go version
 
-    - name: go test
-      run: go test ./... -cover -race
+      - name: go mod tidy (fails if changes are needed)
+        run: go mod tidy --diff
 
-    - name: "smoke test"
-      run: cd example && go build . && ./example 
+      - name: Go test
+        run: go test ./... -cover -race
+
+      - name: Build example
+        run: cd example && go build .
+
+      - name: "smoke test"
+        run: cd example && ./example

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,4 +1,5 @@
 name: golangci-lint
+
 on:
   push:
     branches:
@@ -8,10 +9,10 @@ on:
 
 permissions:
   contents: read
-  
+
   # Optional: allow read access to pull request. Use with `only-new-issues` option.
   pull-requests: read
-  
+
   # Optional: allow write access to checks to allow the action to annotate code in the PR.
   checks: write
 
@@ -21,10 +22,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      
-      - uses: actions/setup-go@v5
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
         with:
-          go-version: '1.23.x'
+          go-version-file: go.mod
+          check-latest: true
+
       - name: Display Go version
         run: go version
 
@@ -32,5 +36,4 @@ jobs:
         uses: golangci/golangci-lint-action@v6
         with:
           version: latest
-          only-new-issues: true
-          cache-invalidation-interval: 14
+          cache-invalidation-interval: 30

--- a/README.md
+++ b/README.md
@@ -1,14 +1,17 @@
-# Finite State Machine (FSM) Package for Go
-A flexible and thread-safe finite state machine (FSM) implementation for Go. This library allows
-you to define custom states and transitions, manage state changes, and subscribe to state updates
-using channels.
+# go-fsm
+
+[![Go Reference](https://pkg.go.dev/badge/github.com/robbyt/go-fsm.svg)](https://pkg.go.dev/github.com/robbyt/go-fsm)
+[![Go Report Card](https://goreportcard.com/badge/github.com/robbyt/go-fsm)](https://goreportcard.com/report/github.com/robbyt/go-fsm)
+[![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
+
+A thread-safe finite state machine implementation for Go that supports custom states, transitions, and state change notifications.
 
 ## Features
 
 - Define custom states and allowed transitions
-- Thread-safe state management
-- Subscribe to state changes via channels
-- Logging support using the standard library's `log/slog`
+- Thread-safe state management using atomic operations
+- Subscribe to state changes via channels with context support
+- Structured logging via `log/slog`
 
 ## Installation
 
@@ -16,92 +19,139 @@ using channels.
 go get github.com/robbyt/go-fsm
 ```
 
-## Usage
-A full example is available in [`example/main.go`](example/main.go).
-
-### Defining States and Transitions
-Define your custom states and the allowed transitions between them. There are also some predefined
-states available in [`allowedTransitions.go`](allowedTransitions.go).
+## Quick Start
 
 ```go
+package main
+
 import (
-    "github.com/robbyt/go-fsm"
-)
+	"context"
+	"log/slog"
+	"os"
+	"time"
 
-// Define custom states
-const (
-    StatusOnline  = "StatusOnline"
-    StatusOffline = "StatusOffline"
-    StatusUnknown = "StatusUnknown"
-)
-
-// Define allowed transitions
-var allowedTransitions = fsm.TransitionsConfig{
-    StatusOnline:   string[]{StatusOffline, StatusUnknown},
-    StatusOffline:  string[]{StatusOnline, StatusUnknown},
-    StatusUnknown:  string[]{},
-}
-```
-
-### Creating a New FSM
-Create a new FSM instance by providing an initial state and the allowed transitions. You can also
-provide a logger using the standard library's log/slog.
-
-
-```go
-import (
-    "github.com/robbyt/go-fsm"
-    "log/slog"
+	"github.com/robbyt/go-fsm"
 )
 
 func main() {
-    // Get the default logger
-    logger := slog.Default()
+	// Create a logger
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 
-    // Create a new FSM, with the initial state and allowed transitions from built-in states
-    machine, err := fsm.New(logger.Handler(), fsm.StatusNew, fsm.TypicalTransitions)
-    if err != nil {
-        logger.Error("Failed to create FSM", "error", err)
-        return
-    }
+	// Create a new FSM with initial state and predefined transitions
+	machine, err := fsm.New(logger.Handler(), fsm.StatusNew, fsm.TypicalTransitions)
+	if err != nil {
+		logger.Error("failed to create FSM", "error", err)
+		return
+	}
+
+	// Subscribe to state changes
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	
+	stateChan := machine.GetStateChan(ctx)
+	
+	go func() {
+		for state := range stateChan {
+			logger.Info("state changed", "state", state)
+		}
+	}()
+
+	// Perform state transitions
+	if err := machine.Transition(fsm.StatusRunning); err != nil {
+		logger.Error("transition failed", "error", err)
+		return
+	}
+
+	time.Sleep(time.Second)
+	
+	if err := machine.Transition(fsm.StatusStopped); err != nil {
+		logger.Error("transition failed", "error", err)
+		return
+	}
 }
 ```
 
+## Usage
+
+### Defining Custom States and Transitions
+
 ```go
-    // Alternatively, create a new handler with custom options, and pass that handler variable
-    handler := slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
-        Level: slog.LevelDebug,
-    )
-    machine, err := fsm.New(handler, fsm.StatusNew, fsm.TypicalTransitions)
+// Define custom states
+const (
+	StatusOnline  = "StatusOnline"
+	StatusOffline = "StatusOffline"
+	StatusUnknown = "StatusUnknown"
+)
+
+// Define allowed transitions
+var customTransitions = fsm.TransitionsConfig{
+	StatusOnline:  []string{StatusOffline, StatusUnknown},
+	StatusOffline: []string{StatusOnline, StatusUnknown},
+	StatusUnknown: []string{},
+}
 ```
 
-### Performing State Transitions
-Transition between states using the Transition method. It ensures that the transition adheres to
-the allowed transitions.
+### Creating an FSM
 
 ```go
-err = machine.Transition(StateRunning)
+// Create with default options
+machine, err := fsm.New(slog.Default().Handler(), StatusOnline, customTransitions)
 if err != nil {
-    logger.Error("Transition failed", "error", err)
+	// Handle error
 }
+
+// Or with custom logger options
+handler := slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+	Level: slog.LevelDebug,
+})
+machine, err := fsm.New(handler, StatusOnline, customTransitions)
 ```
 
-### Subscribing to State Changes
-Subscribe to state changes by obtaining a channel that emits the FSM's state whenever it changes.
+### State Transitions
 
 ```go
+// Simple transition
+err := machine.Transition(StatusOffline)
+
+// Conditional transition
+err := machine.TransitionIfCurrentState(StatusOnline, StatusOffline)
+
+// Get current state
+currentState := machine.GetState()
+```
+
+### State Change Notifications
+
+```go
+// Get notification channel
 ctx, cancel := context.WithCancel(context.Background())
 defer cancel()
 
 stateChan := machine.GetStateChan(ctx)
 
+// Process state changes
 go func() {
-    for state := range stateChan {
-        logger.Info("State changed", "state", state)
-    }
+	for state := range stateChan {
+		// Handle state change
+		fmt.Println("State changed to:", state)
+	}
 }()
+
+// Alternative: Add a subscriber with custom callback
+unsubscribe := machine.AddSubscriber(func(state string) {
+	fmt.Println("State updated:", state)
+})
+defer unsubscribe() // Call to stop receiving updates
 ```
+
+## Complete Example
+
+See [`example/main.go`](example/main.go) for a complete example application.
+
+## Thread Safety
+
+All operations on the FSM are thread-safe and can be used concurrently from multiple goroutines.
 
 ## License
 
-This project is licensed under the Apache License 2.0
+Apache License 2.0 - See [LICENSE](LICENSE) for details.

--- a/example/main.go
+++ b/example/main.go
@@ -1,9 +1,26 @@
+/*
+Copyright 2024 Robert Terhaar <robbyt@robbyt.net>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package main
 
 import (
 	"context"
 	"log/slog"
 	"os"
+	"time"
 
 	"github.com/robbyt/go-fsm"
 )
@@ -46,31 +63,42 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Create a done channel for synchronization
+	done := make(chan struct{})
+
 	// Listen for state changes, and print them
 	listener := fsm.GetStateChan(ctx)
 	go func() {
+		defer close(done)
 		for {
 			select {
 			case state := <-listener:
 				logger.Info("State change received", "state", state)
 
 				if state == StatusOffline {
+					logger.Info("Received offline state, canceling context...")
 					cancel()
+					return
 				}
 
 			case <-ctx.Done():
+				logger.Debug("Context done, exiting listener")
 				return
 			}
 		}
 	}()
 
-	// Transition to a new state
+	// Transition to a new state after a small delay
+	// to ensure the goroutine is running
+	time.Sleep(50 * time.Millisecond)
+	logger.Debug("Transitioning to offline state")
 	err = fsm.Transition(StatusOffline)
 	if err != nil {
 		logger.Error(err.Error())
 		os.Exit(1)
 	}
 
-	<-ctx.Done()
+	// Wait for the done signal from the goroutine
+	<-done
 	logger.Info("Done.")
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/robbyt/go-fsm
 
-go 1.23.3
+go 1.24.1
 
 require github.com/stretchr/testify v1.10.0
 

--- a/stateChan_test.go
+++ b/stateChan_test.go
@@ -1,24 +1,7 @@
-/*
-Copyright 2024 Robert Terhaar <robbyt@robbyt.net>
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-	http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package fsm
 
 import (
 	"context"
-	"sync"
 	"testing"
 	"time"
 
@@ -29,19 +12,19 @@ import (
 func TestFSM_GetStatusChan(t *testing.T) {
 	t.Parallel()
 
-	t.Run("Nil context", func(t *testing.T) {
+	t.Run("TODO context", func(t *testing.T) {
 		fsm, err := New(nil, StatusNew, TypicalTransitions)
 		require.NoError(t, err)
 
-		statusChan := fsm.GetStateChan(nil)
+		statusChan := fsm.GetStateChan(context.TODO())
 		require.NotNil(t, statusChan)
 
+		// With new implementation, initial state should be sent immediately
 		select {
-		case status, ok := <-statusChan:
+		case status := <-statusChan:
 			assert.Equal(t, StatusNew, status)
-			assert.True(t, ok)
 		case <-time.After(time.Second):
-			t.Fatal("Timed out waiting for channel to close")
+			t.Fatal("Timed out waiting for initial state")
 		}
 	})
 
@@ -56,227 +39,205 @@ func TestFSM_GetStatusChan(t *testing.T) {
 		require.NotNil(t, statusChan)
 
 		select {
-		case state, ok := <-statusChan:
-			require.True(t, ok)
-			assert.Equal(t, StatusNew, state)
+		case status := <-statusChan:
+			assert.Equal(t, StatusNew, status)
+		case <-time.After(time.Second):
+			t.Fatal("Timed out waiting for initial state")
+		}
+	})
+
+	t.Run("Channel is closed when context is canceled", func(t *testing.T) {
+		fsm, err := New(nil, StatusNew, TypicalTransitions)
+		require.NoError(t, err)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		statusChan := fsm.GetStateChan(ctx)
+		require.NotNil(t, statusChan)
+
+		// First receive the initial state
+		select {
+		case status := <-statusChan:
+			assert.Equal(t, StatusNew, status)
 		case <-time.After(time.Second):
 			t.Fatal("Timed out waiting for initial state")
 		}
 
+		// Cancel the context
 		cancel()
 
+		// The channel should be closed
 		select {
-		case _, ok := <-statusChan:
-			assert.False(t, ok, "Channel should be closed after context is canceled")
+		case status, ok := <-statusChan:
+			assert.False(t, ok, "Channel should be closed")
+			assert.Empty(t, status, "Value should be empty on a closed channel")
 		case <-time.After(time.Second):
 			t.Fatal("Timed out waiting for channel to close")
 		}
-
 	})
 
-	t.Run("State changes are emitted", func(t *testing.T) {
+	t.Run("State transitions are broadcast to subscribers", func(t *testing.T) {
 		fsm, err := New(nil, StatusNew, TypicalTransitions)
 		require.NoError(t, err)
 
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		statusChan := fsm.GetStateChan(ctx)
+		// Create two subscribers
+		ch1 := fsm.GetStateChan(ctx)
+		ch2 := fsm.GetStateChan(ctx)
 
-		var receivedStates []string
-		done := make(chan struct{})
-		ready := make(chan struct{})
+		// Consume initial states
+		<-ch1
+		<-ch2
 
-		go func() {
-			close(ready)
-			for state := range statusChan {
-				receivedStates = append(receivedStates, state)
-				if state == StatusError {
-					close(done)
-					return
-				}
-			}
-		}()
-
-		// Wait for the goroutine to start
-		<-ready
-
-		// Perform rapid state transitions
+		// Transition to a new state
 		err = fsm.Transition(StatusBooting)
 		require.NoError(t, err)
 
-		err = fsm.Transition(StatusRunning)
-		require.NoError(t, err)
-
-		err = fsm.Transition(StatusError)
-		require.NoError(t, err)
-
+		// Both channels should receive the new state
 		select {
-		case <-done:
-		case <-time.After(5 * time.Second):
-			t.Fatal("Timed out waiting for state changes")
+		case status := <-ch1:
+			assert.Equal(t, StatusBooting, status)
+		case <-time.After(time.Second):
+			t.Fatal("Timed out waiting for status update on channel 1")
 		}
 
-		expectedStates := []string{StatusNew, StatusBooting, StatusRunning, StatusError}
-		assert.Equal(t, expectedStates, receivedStates)
+		select {
+		case status := <-ch2:
+			assert.Equal(t, StatusBooting, status)
+		case <-time.After(time.Second):
+			t.Fatal("Timed out waiting for status update on channel 2")
+		}
 	})
 
-	t.Run("Multiple subscribers receive updates", func(t *testing.T) {
+	t.Run("AddSubscriber", func(t *testing.T) {
 		fsm, err := New(nil, StatusNew, TypicalTransitions)
 		require.NoError(t, err)
 
-		ctx1, cancel1 := context.WithCancel(context.Background())
-		defer cancel1()
-		ctx2, cancel2 := context.WithCancel(context.Background())
-		defer cancel2()
+		ch := make(chan string, 1)
+		unsub := fsm.AddSubscriber(ch)
+		defer unsub()
 
-		statusChan1 := fsm.GetStateChan(ctx1)
-		statusChan2 := fsm.GetStateChan(ctx2)
+		// Should receive the initial state
+		select {
+		case status := <-ch:
+			assert.Equal(t, StatusNew, status)
+		case <-time.After(time.Second):
+			t.Fatal("Timed out waiting for initial state")
+		}
 
-		require.NotNil(t, statusChan1)
-		require.NotNil(t, statusChan2)
-
-		var wg sync.WaitGroup
-		var mu sync.Mutex
-		received1 := []string{}
-		received2 := []string{}
-
-		wg.Add(2)
-
-		go func() {
-			defer wg.Done()
-			for state := range statusChan1 {
-				mu.Lock()
-				received1 = append(received1, state)
-				mu.Unlock()
-				if state == StatusRunning {
-					return
-				}
-			}
-		}()
-
-		go func() {
-			defer wg.Done()
-			for state := range statusChan2 {
-				mu.Lock()
-				received2 = append(received2, state)
-				mu.Unlock()
-				if state == StatusRunning {
-					return
-				}
-			}
-		}()
-
+		// Transition to a new state
 		err = fsm.Transition(StatusBooting)
 		require.NoError(t, err)
 
+		// Should receive the state update
+		select {
+		case status := <-ch:
+			assert.Equal(t, StatusBooting, status)
+		case <-time.After(time.Second):
+			t.Fatal("Timed out waiting for state update")
+		}
+
+		// Unsubscribe
+		unsub()
+
+		// Transition to another state
 		err = fsm.Transition(StatusRunning)
 		require.NoError(t, err)
 
-		wg.Wait()
-
-		mu.Lock()
-		expectedStates := []string{StatusNew, StatusBooting, StatusRunning}
-		assert.Equal(t, expectedStates, received1)
-		assert.Equal(t, expectedStates, received2)
-		mu.Unlock()
+		// Should not receive any update after unsubscribing
+		select {
+		case status := <-ch:
+			t.Fatalf("Received unexpected state update: %s", status)
+		case <-time.After(100 * time.Millisecond):
+			// This is the expected outcome - no state update after unsubscribing
+		}
 	})
-}
 
-func TestFSM_SetChanBufferSize(t *testing.T) {
-	fsm, err := New(nil, StatusNew, TypicalTransitions)
-	require.NoError(t, err)
-	require.Equal(t, defaultStateChanBufferSize, fsm.channelBufferSize, "assume the default buffer size is set upon creation")
+	t.Run("Multiple subscribers", func(t *testing.T) {
+		fsm, err := New(nil, StatusNew, TypicalTransitions)
+		require.NoError(t, err)
 
-	// Change the buffer size before creating subscribers
-	newBufferSize := 1
-	fsm.SetChanBufferSize(newBufferSize)
-	require.Equal(t, newBufferSize, fsm.channelBufferSize, "buffer size should be updated after running SetChanBufferSize")
+		var channels []chan string
+		var unsubscribers []func()
+		numSubscribers := 5
 
-	fsm.SetChanBufferSize(-1)
-	require.Equal(t, newBufferSize, fsm.channelBufferSize, "buffer size remains the same if the new size is invalid")
+		// Create multiple subscribers
+		for i := 0; i < numSubscribers; i++ {
+			ch := make(chan string, 1)
+			unsub := fsm.AddSubscriber(ch)
+			channels = append(channels, ch)
+			unsubscribers = append(unsubscribers, unsub)
+		}
 
-	fsm.SetChanBufferSize(newBufferSize)
-	require.Equal(t, newBufferSize, fsm.channelBufferSize, "buffer size remains the same if the new size is the same as the current size")
+		// Defer cleanup
+		defer func() {
+			for _, unsub := range unsubscribers {
+				unsub()
+			}
+		}()
 
-	// Create subscribers after changing buffer size
-	ctx1, cancel1 := context.WithCancel(context.Background())
-	defer cancel1()
-	statusChan1 := fsm.GetStateChan(ctx1)
-	require.NotNil(t, statusChan1)
-
-	ctx2, cancel2 := context.WithCancel(context.Background())
-	defer cancel2()
-	statusChan2 := fsm.GetStateChan(ctx2)
-	require.NotNil(t, statusChan2)
-
-	// Define a valid sequence of state transitions
-	transitions := []string{
-		StatusBooting,  // From StatusNew
-		StatusRunning,  // From StatusBooting
-		StatusStopping, // From StatusRunning
-		StatusStopped,  // From StatusStopping
-		StatusNew,      // From StatusStopped
-	}
-
-	// Collect states for the first subscriber
-	var received1 []string
-	done1 := make(chan struct{})
-	go func() {
-		for state := range statusChan1 {
-			received1 = append(received1, state)
-			if len(received1) >= newBufferSize {
-				close(done1)
-				return
+		// Consume initial states
+		for i, ch := range channels {
+			select {
+			case status := <-ch:
+				assert.Equal(t, StatusNew, status)
+			case <-time.After(time.Second):
+				t.Fatalf("Timed out waiting for initial state on channel %d", i)
 			}
 		}
-	}()
 
-	// Collect states for the second subscriber
-	var received2 []string
-	done2 := make(chan struct{})
-	go func() {
-		for state := range statusChan2 {
-			received2 = append(received2, state)
-			if len(received2) >= newBufferSize {
-				close(done2)
-				return
+		// Transition to a new state
+		err = fsm.Transition(StatusBooting)
+		require.NoError(t, err)
+
+		// All channels should receive the state update
+		for i, ch := range channels {
+			select {
+			case status := <-ch:
+				assert.Equal(t, StatusBooting, status)
+			case <-time.After(time.Second):
+				t.Fatalf("Timed out waiting for state update on channel %d", i)
 			}
 		}
-	}()
+	})
 
-	// Perform multiple state transitions in the background
-	go func() {
-		for i := 0; i < newBufferSize; i++ {
-			currentState := fsm.GetState()
-			nextState := transitions[i%len(transitions)]
+	t.Run("Single state transition", func(t *testing.T) {
+		fsm, err := New(nil, StatusNew, TypicalTransitions)
+		require.NoError(t, err)
 
-			// Check if transition is valid before attempting
-			if _, ok := fsm.allowedTransitions[currentState][nextState]; !ok {
-				// Reset FSM to a valid state
-				err := fsm.SetState(StatusNew)
-				require.NoError(t, err)
-				nextState = StatusBooting
-			}
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
 
-			err := fsm.Transition(nextState)
-			require.NoError(t, err)
+		// Create several channels
+		numChans := 3
+		stateChan := make([]<-chan string, numChans)
+		for i := 0; i < numChans; i++ {
+			stateChan[i] = fsm.GetStateChan(ctx)
 		}
-	}()
 
-	select {
-	case <-done1:
-	case <-time.After(5 * time.Second):
-		t.Fatal("Timed out waiting for states on subscriber 1")
-	}
+		// Read all the initial states
+		for i, ch := range stateChan {
+			select {
+			case state := <-ch:
+				assert.Equal(t, StatusNew, state)
+			case <-time.After(time.Second):
+				t.Fatalf("Channel %d never received initial state", i)
+			}
+		}
 
-	select {
-	case <-done2:
-	case <-time.After(5 * time.Second):
-		t.Fatal("Timed out waiting for states on subscriber 2")
-	}
+		// Transition to a new state
+		err = fsm.Transition(StatusBooting)
+		require.NoError(t, err)
 
-	// Verify the number of received states
-	assert.Len(t, received1, newBufferSize)
-	assert.Len(t, received2, newBufferSize)
+		// Verify all subscribers got the state update
+		for i, ch := range stateChan {
+			select {
+			case state := <-ch:
+				assert.Equal(t, StatusBooting, state)
+			case <-time.After(time.Second):
+				t.Fatalf("Channel %d never received state update", i)
+			}
+		}
+	})
 }

--- a/stateChan_test.go
+++ b/stateChan_test.go
@@ -12,6 +12,18 @@ import (
 func TestFSM_GetStatusChan(t *testing.T) {
 	t.Parallel()
 
+	t.Run("nil context guard check", func(t *testing.T) {
+		fsm, err := New(nil, StatusNew, TypicalTransitions)
+		require.NoError(t, err)
+
+		// Create a nil Context variable to test the guard
+		// This approach avoids the linter warning while still testing nil context behavior
+		var nilCtx context.Context
+		
+		statusChan := fsm.GetStateChan(nilCtx)
+		assert.Nil(t, statusChan, "Should return nil when context is nil")
+	})
+
 	t.Run("TODO context", func(t *testing.T) {
 		fsm, err := New(nil, StatusNew, TypicalTransitions)
 		require.NoError(t, err)
@@ -154,6 +166,39 @@ func TestFSM_GetStatusChan(t *testing.T) {
 		}
 	})
 
+	t.Run("AddSubscriber with full channel", func(t *testing.T) {
+		fsm, err := New(nil, StatusNew, TypicalTransitions)
+		require.NoError(t, err)
+
+		// Create a buffered channel of size 1 and fill it
+		ch := make(chan string, 1)
+		ch <- "existing-value"
+
+		// Channel is now full, so initial state won't be sent
+		unsub := fsm.AddSubscriber(ch)
+		defer unsub()
+
+		// Make sure the channel still contains only the original value
+		select {
+		case val := <-ch:
+			assert.Equal(t, "existing-value", val, "Channel should still contain original value")
+		case <-time.After(100 * time.Millisecond):
+			t.Fatal("Should be able to read existing value from channel")
+		}
+
+		// Now the channel is empty, transition to a new state
+		err = fsm.Transition(StatusBooting)
+		require.NoError(t, err)
+
+		// Should receive the state update now that the channel has space
+		select {
+		case status := <-ch:
+			assert.Equal(t, StatusBooting, status)
+		case <-time.After(time.Second):
+			t.Fatal("Timed out waiting for state update")
+		}
+	})
+
 	t.Run("Multiple subscribers", func(t *testing.T) {
 		fsm, err := New(nil, StatusNew, TypicalTransitions)
 		require.NoError(t, err)
@@ -200,6 +245,103 @@ func TestFSM_GetStatusChan(t *testing.T) {
 				t.Fatalf("Timed out waiting for state update on channel %d", i)
 			}
 		}
+	})
+
+	t.Run("Broadcast skips full channels", func(t *testing.T) {
+		fsm, err := New(nil, StatusNew, TypicalTransitions)
+		require.NoError(t, err)
+
+		// Create a non-buffered channel - we won't read from it
+		// This simulates a slow consumer that's not keeping up
+		nonBufferedCh := make(chan string)
+		nonBufferedUnsub := fsm.AddSubscriber(nonBufferedCh)
+		defer nonBufferedUnsub()
+
+		// Create a normal buffered channel that will receive updates
+		bufferedCh := make(chan string, 2)
+		bufferedUnsub := fsm.AddSubscriber(bufferedCh)
+		defer bufferedUnsub()
+
+		// Read initial state from buffered channel
+		select {
+		case state := <-bufferedCh:
+			assert.Equal(t, StatusNew, state)
+		case <-time.After(time.Second):
+			t.Fatal("Timed out waiting for initial state on buffered channel")
+		}
+
+		// Perform multiple transitions quickly
+		// The non-buffered channel won't be able to keep up, but the FSM shouldn't block
+		for _, state := range []string{StatusBooting, StatusRunning, StatusReloading} {
+			err := fsm.Transition(state)
+			require.NoError(t, err, "Transition should succeed even with blocked channels")
+
+			// Each transition should be received on the buffered channel
+			select {
+			case receivedState := <-bufferedCh:
+				assert.Equal(t, state, receivedState)
+			case <-time.After(time.Second):
+				t.Fatalf("Timed out waiting for state %s on buffered channel", state)
+			}
+		}
+
+		// The final state should match our expected state
+		assert.Equal(t, StatusReloading, fsm.GetState(), "Final state should be StatusReloading")
+	})
+
+	t.Run("Check consumer with indirect channel", func(t *testing.T) {
+		fsm, err := New(nil, StatusNew, TypicalTransitions)
+		require.NoError(t, err)
+
+		// Create a channel and subscribe
+		statesChan := make(chan string, 3)
+
+		// Monitor states in a separate goroutine
+		statesReceived := make([]string, 0, 3)
+		done := make(chan struct{})
+
+		// Start a goroutine to handle processing the received states
+		go func() {
+			defer close(done)
+			for state := range statesChan {
+				statesReceived = append(statesReceived, state)
+			}
+		}()
+
+		// Subscribe the channel
+		unsub := fsm.AddSubscriber(statesChan)
+
+		// Allow some time for initial state to be received
+		time.Sleep(50 * time.Millisecond)
+
+		// Make state transitions
+		transitions := []string{StatusBooting, StatusRunning}
+		for _, state := range transitions {
+			err = fsm.Transition(state)
+			require.NoError(t, err)
+			time.Sleep(50 * time.Millisecond) // Give time for state to propagate
+		}
+
+		// Unsubscribe and close the channel
+		unsub()
+		close(statesChan)
+
+		// Wait for the goroutine to process all states
+		select {
+		case <-done:
+			// Success
+		case <-time.After(time.Second):
+			t.Fatal("Timed out waiting for goroutine to finish")
+		}
+
+		// Verify all expected states were received
+		expected := []string{StatusNew, StatusBooting, StatusRunning}
+		assert.Equal(t, expected, statesReceived, "Should have received all state transitions")
+
+		// Verify a transition after unsubscribe doesn't affect anything
+		err = fsm.Transition(StatusStopped)
+		require.NoError(t, err)
+		assert.Equal(t, expected, statesReceived, "States shouldn't change after unsubscribe")
 	})
 
 	t.Run("Single state transition", func(t *testing.T) {

--- a/transitionConfig.go
+++ b/transitionConfig.go
@@ -16,12 +16,15 @@ limitations under the License.
 
 package fsm
 
+// TransitionsConfig represents a configuration for allowed transitions the FSM.
 type TransitionsConfig map[string][]string
 
-type transitionConfigWithIndex map[string]map[string]struct{}
+// transitionIndex is a map of maps, the second map is like a set, used for
+type transitionIndex map[string]map[string]struct{}
 
-func newTransitionWithIndex(transCfg TransitionsConfig) transitionConfigWithIndex {
-	t := make(transitionConfigWithIndex)
+// makeIndex called during fsm creation, creates a transitionIndex from a TransitionsConfig.
+func makeIndex(transCfg TransitionsConfig) transitionIndex {
+	t := make(transitionIndex)
 
 	for from, to := range transCfg {
 		if _, ok := t[from]; !ok {

--- a/transitionConfig_test.go
+++ b/transitionConfig_test.go
@@ -14,11 +14,11 @@ func TestNewTransitionWithIndex(t *testing.T) {
 		"StateB": {"StateC", "StateD"},
 	}
 
-	expected := transitionConfigWithIndex{
+	expected := transitionIndex{
 		"StateA": {"StateB": {}, "StateC": {}},
 		"StateB": {"StateC": {}, "StateD": {}},
 	}
 
-	result := newTransitionWithIndex(transitions)
+	result := makeIndex(transitions)
 	assert.Equal(t, expected, result)
 }


### PR DESCRIPTION
This also adds a new public function `AddSubscriber` which allows adding a subscriber by passing in an external channel.