### PR TITLE
add new subscriber method GetStateChanWithOptions

### DIFF
--- a/stateChan.go
+++ b/stateChan.go
@@ -16,11 +16,103 @@ limitations under the License.
 
 package fsm
 
-import "context"
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+const (
+	defaultSyncTimeout = 10 * time.Second
+)
+
+// SubscriberOption configures subscriber behavior
+type SubscriberOption func(*subscriberConfig)
+
+// subscriberConfig holds configuration for subscriber channels
+type subscriberConfig struct {
+	sendInitial   bool
+	customChannel chan string
+	syncBroadcast bool
+	syncTimeout   time.Duration
+}
+
+// WithBufferSize creates a channel with the specified buffer size
+func WithBufferSize(size int) SubscriberOption {
+	return func(config *subscriberConfig) {
+		config.customChannel = make(chan string, size)
+	}
+}
+
+// WithoutInitialState prevents sending the current state of the FSM immediately after creation
+func WithoutInitialState() SubscriberOption {
+	return func(config *subscriberConfig) {
+		config.sendInitial = false
+	}
+}
+
+// WithCustomChannel uses an external channel instead of creating a new one
+func WithCustomChannel(ch chan string) SubscriberOption {
+	return func(config *subscriberConfig) {
+		config.customChannel = ch
+	}
+}
+
+// WithSyncBroadcast enables synchronous broadcasting that blocks until the message
+// is delivered to the channel, rather than dropping messages for full channels
+func WithSyncBroadcast() SubscriberOption {
+	return func(config *subscriberConfig) {
+		config.syncBroadcast = true
+	}
+}
+
+// WithSyncTimeout sets the timeout for synchronous broadcast operations
+func WithSyncTimeout(timeout time.Duration) SubscriberOption {
+	return func(config *subscriberConfig) {
+		config.syncTimeout = timeout
+	}
+}
 
 // GetStateChan returns a channel that will receive the current state of the FSM immediately.
 func (fsm *Machine) GetStateChan(ctx context.Context) <-chan string {
 	return fsm.GetStateChanBuffer(ctx, 1)
+}
+
+// GetStateChanWithOptions returns a channel configured with functional options
+func (fsm *Machine) GetStateChanWithOptions(
+	ctx context.Context,
+	opts ...SubscriberOption,
+) <-chan string {
+	config := &subscriberConfig{
+		sendInitial: true,
+		syncTimeout: defaultSyncTimeout,
+	}
+
+	for _, opt := range opts {
+		opt(config)
+	}
+
+	if ctx == nil {
+		fsm.logger.Error("context is nil; cannot create state channel")
+		return nil
+	}
+
+	var ch chan string
+	if config.customChannel != nil {
+		ch = config.customChannel
+	} else {
+		ch = make(chan string, 1)
+	}
+
+	unsubCallback := fsm.addSubscriberWithConfig(ch, config)
+
+	go func() {
+		<-ctx.Done()
+		unsubCallback()
+		close(ch)
+	}()
+
+	return ch
 }
 
 // GetStateChanBuffer returns a channel with a configurable buffer size. The current state
@@ -50,19 +142,32 @@ func (fsm *Machine) GetStateChanBuffer(ctx context.Context, chanBufferSize int) 
 // the current state if the channel (if possible), and will also receive future state changes
 // when the FSM state is updated. A callback function is returned that should be called to
 // remove the channel from the list of subscribers when this is no longer needed.
+//
+// Deprecated: Use GetStateChanWithOptions with WithCustomChannel instead.
 func (fsm *Machine) AddSubscriber(ch chan string) func() {
+	config := &subscriberConfig{
+		sendInitial: true,
+		syncTimeout: defaultSyncTimeout,
+	}
+	return fsm.addSubscriberWithConfig(ch, config)
+}
+
+// addSubscriberWithConfig adds a subscriber with specific configuration
+func (fsm *Machine) addSubscriberWithConfig(ch chan string, config *subscriberConfig) func() {
 	fsm.subscriberMutex.Lock()
 	defer fsm.subscriberMutex.Unlock()
 
-	fsm.subscribers.Store(ch, struct{}{})
+	fsm.subscribers.Store(ch, config)
 
-	select {
-	case ch <- fsm.GetState():
-		fsm.logger.Debug("Sent initial state to channel")
-	default:
-		fsm.logger.Warn(
-			"Unable to write initial state to channel; next state change will be sent instead",
-		)
+	if config.sendInitial {
+		select {
+		case ch <- fsm.GetState():
+			fsm.logger.Debug("Sent initial state to channel")
+		default:
+			fsm.logger.Warn(
+				"Unable to write initial state to channel; next state change will be sent instead",
+			)
+		}
 	}
 
 	return func() {
@@ -78,7 +183,8 @@ func (fsm *Machine) unsubscribe(ch chan string) {
 }
 
 // broadcast sends the new state to all subscriber channels.
-// If a channel is full, the state change is skipped for that channel, and a warning is logged.
+// For async subscribers, if a channel is full, the state change is skipped for that channel, and a warning is logged.
+// For sync subscribers, the broadcast blocks until the message is delivered or times out after 10 seconds.
 // This, and the other subscriber-related methods, use a standard mutex instead of an RWMutex,
 // because the broadcast sends should always be serial, and never concurrent, otherwise the order
 // of state change notifications could be unpredictable.
@@ -90,14 +196,45 @@ func (fsm *Machine) broadcast(state string) {
 	fsm.subscriberMutex.Lock()
 	defer fsm.subscriberMutex.Unlock()
 
+	var wg sync.WaitGroup
+
 	fsm.subscribers.Range(func(key, value any) bool {
 		ch := key.(chan string)
-		select {
-		case ch <- state:
-			logger.Debug("Sent state to channel")
-		default:
-			logger.Debug("Channel is full; skipping broadcast for subscriber")
+
+		// Handle type assertion safely
+		config, ok := value.(*subscriberConfig)
+		if !ok {
+			logger.Error("Invalid subscriber config type; skipping subscriber")
+			return true
+		}
+
+		if config.syncBroadcast {
+			// Handle sync broadcast with timeout in parallel goroutines
+			wg.Add(1)
+			go func(ch chan string) {
+				defer wg.Done()
+				select {
+				case ch <- state:
+					logger.Debug("State delivered to synchronous subscriber")
+				case <-time.After(config.syncTimeout):
+					logger.Warn("Synchronous subscriber blocked; state delivery timed out",
+						"timeout", config.syncTimeout,
+						"channel_capacity", cap(ch), "channel_length", len(ch))
+				}
+			}(ch)
+		} else {
+			// Handle async broadcast (non-blocking)
+			select {
+			case ch <- state:
+				logger.Debug("State delivered to asynchronous subscriber")
+			default:
+				logger.Debug("Asynchronous subscriber channel full; state delivery skipped",
+					"channel_capacity", cap(ch), "channel_length", len(ch))
+			}
 		}
 		return true // continue iteration
 	})
+
+	// Wait for all sync broadcasts to complete or timeout
+	wg.Wait()
 }

--- a/stateChan_test.go
+++ b/stateChan_test.go
@@ -47,9 +47,7 @@ func TestFSM_GetStatusChan(t *testing.T) {
 	t.Run("Initial state is sent immediately", func(t *testing.T) {
 		fsm, err := New(nil, StatusNew, TypicalTransitions)
 		require.NoError(t, err)
-
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+		ctx := t.Context()
 
 		statusChan := fsm.GetStateChan(ctx)
 		require.NotNil(t, statusChan)
@@ -67,8 +65,7 @@ func TestFSM_GetStatusChan(t *testing.T) {
 	t.Run("Channel is closed when context is canceled", func(t *testing.T) {
 		fsm, err := New(nil, StatusNew, TypicalTransitions)
 		require.NoError(t, err)
-
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(t.Context())
 		statusChan := fsm.GetStateChan(ctx)
 		require.NotNil(t, statusChan)
 
@@ -95,9 +92,7 @@ func TestFSM_GetStatusChan(t *testing.T) {
 	t.Run("State transitions are broadcast to subscribers", func(t *testing.T) {
 		fsm, err := New(nil, StatusNew, TypicalTransitions)
 		require.NoError(t, err)
-
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+		ctx := t.Context()
 
 		// Create two subscribers
 		ch1 := fsm.GetStateChan(ctx)
@@ -386,8 +381,7 @@ func TestFSM_GetStatusChan(t *testing.T) {
 	t.Run("Single state transition", func(t *testing.T) {
 		fsm, err := New(nil, StatusNew, TypicalTransitions)
 		require.NoError(t, err)
-
-		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		ctx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
 		defer cancel()
 
 		// Create several channels
@@ -433,9 +427,7 @@ func TestFSM_GetStatusChan(t *testing.T) {
 	t.Run("GetStateChan uses buffer size 1", func(t *testing.T) {
 		fsm, err := New(nil, StatusNew, TypicalTransitions)
 		require.NoError(t, err)
-
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+		ctx := t.Context()
 
 		// GetStateChan should behave like GetStateChanBuffer with size 1
 		ch := fsm.GetStateChan(ctx)
@@ -468,9 +460,7 @@ func TestFSM_GetStatusChan(t *testing.T) {
 	t.Run("GetStateChanBuffer with various buffer sizes", func(t *testing.T) {
 		fsm, err := New(nil, StatusNew, TypicalTransitions)
 		require.NoError(t, err)
-
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+		ctx := t.Context()
 
 		// Test buffer size 0 (unbuffered)
 		ch0 := fsm.GetStateChanBuffer(ctx, 0)
@@ -527,9 +517,7 @@ func TestFSM_GetStatusChan(t *testing.T) {
 	t.Run("GetStateChanBuffer with rapid transitions", func(t *testing.T) {
 		fsm, err := New(nil, StatusNew, TypicalTransitions)
 		require.NoError(t, err)
-
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+		ctx := t.Context()
 
 		// Create channel with buffer size 3
 		ch := fsm.GetStateChanBuffer(ctx, 3)
@@ -561,9 +549,7 @@ func TestFSM_GetStatusChan(t *testing.T) {
 	t.Run("GetStateChanBuffer with small buffer overflow", func(t *testing.T) {
 		fsm, err := New(nil, StatusNew, TypicalTransitions)
 		require.NoError(t, err)
-
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+		ctx := t.Context()
 
 		// Create channel with buffer size 2
 		ch := fsm.GetStateChanBuffer(ctx, 2)
@@ -604,8 +590,7 @@ func TestFSM_GetStatusChan(t *testing.T) {
 	t.Run("GetStateChanBuffer context cancellation", func(t *testing.T) {
 		fsm, err := New(nil, StatusNew, TypicalTransitions)
 		require.NoError(t, err)
-
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(t.Context())
 
 		// Create channels with different buffer sizes
 		ch1 := fsm.GetStateChanBuffer(ctx, 1)
@@ -695,7 +680,7 @@ func TestFSM_GetStatusChan(t *testing.T) {
 
 			// Create many channels that will be immediately unsubscribed and closed
 			// This increases the chance of hitting the race condition
-			for i := 0; i < 10000; i++ {
+			for range 10000 {
 				ch := make(chan string, 1)
 
 				// Add subscriber
@@ -736,7 +721,7 @@ func TestFSM_GetStatusChan(t *testing.T) {
 
 			for i := range 1000 {
 				// Add more subscribers
-				for j := 0; j < 10; j++ {
+				for j := range 10 {
 					idx := (i*10 + j) % len(channels)
 
 					// Clean up previous subscriber at this index if it exists
@@ -806,9 +791,7 @@ func TestFSM_GetStateChanWithOptions(t *testing.T) {
 	t.Run("WithBufferSize option", func(t *testing.T) {
 		fsm, err := New(nil, StatusNew, TypicalTransitions)
 		require.NoError(t, err)
-
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+		ctx := t.Context()
 
 		ch := fsm.GetStateChanWithOptions(ctx, WithBufferSize(5))
 		require.NotNil(t, ch)
@@ -827,9 +810,7 @@ func TestFSM_GetStateChanWithOptions(t *testing.T) {
 	t.Run("WithCustomChannel option", func(t *testing.T) {
 		fsm, err := New(nil, StatusNew, TypicalTransitions)
 		require.NoError(t, err)
-
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+		ctx := t.Context()
 
 		customCh := make(chan string, 3)
 		ch := fsm.GetStateChanWithOptions(ctx, WithCustomChannel(customCh))
@@ -858,9 +839,7 @@ func TestFSM_GetStateChanWithOptions(t *testing.T) {
 	t.Run("WithoutInitialState option", func(t *testing.T) {
 		fsm, err := New(nil, StatusNew, TypicalTransitions)
 		require.NoError(t, err)
-
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+		ctx := t.Context()
 
 		ch := fsm.GetStateChanWithOptions(ctx, WithoutInitialState())
 		require.NotNil(t, ch)
@@ -892,8 +871,7 @@ func TestFSM_GetStateChanWithOptions(t *testing.T) {
 		require.NoError(t, err)
 
 		t.Run("WithCustomChannel overrides WithBufferSize", func(t *testing.T) {
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
+			ctx := t.Context()
 
 			customCh := make(chan string, 10)
 			ch := fsm.GetStateChanWithOptions(ctx, WithBufferSize(5), WithCustomChannel(customCh))
@@ -904,8 +882,7 @@ func TestFSM_GetStateChanWithOptions(t *testing.T) {
 		})
 
 		t.Run("WithBufferSize overrides WithCustomChannel", func(t *testing.T) {
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
+			ctx := t.Context()
 
 			customCh := make(chan string, 2)
 			ch := fsm.GetStateChanWithOptions(ctx, WithCustomChannel(customCh), WithBufferSize(7))
@@ -914,8 +891,7 @@ func TestFSM_GetStateChanWithOptions(t *testing.T) {
 		})
 
 		t.Run("WithoutInitialState persists with other options", func(t *testing.T) {
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
+			ctx := t.Context()
 
 			ch := fsm.GetStateChanWithOptions(ctx, WithoutInitialState(), WithBufferSize(1))
 
@@ -933,9 +909,7 @@ func TestFSM_GetStateChanWithOptions(t *testing.T) {
 	t.Run("No options - default behavior", func(t *testing.T) {
 		fsm, err := New(nil, StatusNew, TypicalTransitions)
 		require.NoError(t, err)
-
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+		ctx := t.Context()
 
 		ch := fsm.GetStateChanWithOptions(ctx)
 		require.NotNil(t, ch)
@@ -963,9 +937,7 @@ func TestFSM_GetStateChanWithOptions(t *testing.T) {
 	t.Run("Combined options", func(t *testing.T) {
 		fsm, err := New(nil, StatusNew, TypicalTransitions)
 		require.NoError(t, err)
-
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+		ctx := t.Context()
 
 		customCh := make(chan string, 2)
 		ch := fsm.GetStateChanWithOptions(ctx, WithCustomChannel(customCh), WithoutInitialState())
@@ -998,9 +970,7 @@ func TestFSM_GetStateChanWithOptions(t *testing.T) {
 	t.Run("WithSyncBroadcast option", func(t *testing.T) {
 		fsm, err := New(nil, StatusNew, TypicalTransitions)
 		require.NoError(t, err)
-
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+		ctx := t.Context()
 
 		// Create a very small buffered channel to test sync behavior
 		ch := fsm.GetStateChanWithOptions(ctx, WithSyncBroadcast(), WithBufferSize(1))
@@ -1051,9 +1021,7 @@ func TestFSM_GetStateChanWithOptions(t *testing.T) {
 	t.Run("WithSyncTimeout option", func(t *testing.T) {
 		fsm, err := New(nil, StatusNew, TypicalTransitions)
 		require.NoError(t, err)
-
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+		ctx := t.Context()
 
 		// Test custom short timeout
 		shortTimeout := 100 * time.Millisecond
@@ -1092,9 +1060,7 @@ func TestFSM_GetStateChanWithOptions(t *testing.T) {
 	t.Run("Mixed sync and async subscribers", func(t *testing.T) {
 		fsm, err := New(nil, StatusNew, TypicalTransitions)
 		require.NoError(t, err)
-
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+		ctx := t.Context()
 
 		// Create async subscriber (default)
 		asyncCh := fsm.GetStateChanWithOptions(ctx, WithBufferSize(2))
@@ -1133,9 +1099,7 @@ func TestFSM_GetStateChanWithOptions(t *testing.T) {
 	t.Run("Sync broadcast with blocked subscriber doesn't block others", func(t *testing.T) {
 		fsm, err := New(nil, StatusNew, TypicalTransitions)
 		require.NoError(t, err)
-
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+		ctx := t.Context()
 
 		// Create one permanently blocked sync subscriber
 		blockedSyncCh := make(chan string) // Unbuffered, no readers
@@ -1174,37 +1138,5 @@ func TestFSM_GetStateChanWithOptions(t *testing.T) {
 				return false
 			}
 		}, time.Second, 10*time.Millisecond, "Async subscriber should receive state despite blocked sync subscriber")
-	})
-
-	t.Run("Default sync timeout", func(t *testing.T) {
-		fsm, err := New(nil, StatusNew, TypicalTransitions)
-		require.NoError(t, err)
-
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-
-		// Test that default timeout is 10 seconds by creating sync subscriber without explicit timeout
-		syncCh := fsm.GetStateChanWithOptions(ctx, WithSyncBroadcast(), WithBufferSize(1))
-		require.NotNil(t, syncCh)
-
-		// We can't easily test a 10-second timeout in a unit test, but we can verify
-		// that the subscriber was created successfully and behaves synchronously
-		// for unblocked channels
-
-		// Consume initial state
-		<-syncCh
-
-		// Quick transition should work fine
-		err = fsm.Transition(StatusBooting)
-		require.NoError(t, err)
-
-		assert.Eventually(t, func() bool {
-			select {
-			case state := <-syncCh:
-				return state == StatusBooting
-			default:
-				return false
-			}
-		}, time.Second, 10*time.Millisecond, "Should receive state with default timeout")
 	})
 }


### PR DESCRIPTION
This change adds a new `GetStateChanWithOptions` method with functional options for configuring state change subscribscription.

  - WithBufferSize(size int) - Creates channel with specified buffer size
  - WithCustomChannel(ch chan string) - Uses external channel instead of creating new one
  - WithoutInitialState() - Prevents sending current state on subscription
  - WithSyncBroadcast() - Blocks until message delivery instead of dropping on full channels
  - WithSyncTimeout(duration) - Sets timeout for synchronous broadcast operations (default 10s)

Examples:
```go
// Buffered channel
ch := fsm.GetStateChanWithOptions(ctx, WithBufferSize(10))

// External channel with blocking broadcast
customCh := make(chan string, 5)
ch := fsm.GetStateChanWithOptions(ctx, WithCustomChannel(customCh), WithSyncBroadcast())

// No initial state sent over the channel, custom timeout
ch := fsm.GetStateChanWithOptions(ctx, WithoutInitialState(), WithSyncTimeout(5*time.Second))
```

Options can be combined and later options override earlier ones. The existing `AddSubscriber` method is deprecated in favor of the new functional options API.