### PR TITLE
docs(transitions): clarify AsMap returns a deep copy

### DIFF
--- a/transitions/config.go
+++ b/transitions/config.go
@@ -113,7 +113,9 @@ func (t *Config) GetAllStates() []string {
 	return states
 }
 
-// AsMap returns a copy of the configuration map.
+// AsMap returns a deep copy of the configuration map.
+// Both the outer map and the inner target slices are cloned, so callers may
+// freely mutate the result without affecting this Config.
 func (t *Config) AsMap() map[string][]string {
 	result := maps.Clone(t.config)
 	for from, tos := range result {


### PR DESCRIPTION
## Summary
- The godoc on `transitions.Config.AsMap` previously said only "returns a copy", which was ambiguous about whether the inner target slices were shared with the underlying `Config`. They are not — both the outer map and the inner slices are cloned.
- This PR clarifies the godoc so callers know they can safely mutate the result.

## Why
Found during a broader audit of the codebase. Tracked as **L3** in the audit report.

## Test plan
- [x] `go test -race -count=1 ./transitions/...`

https://claude.ai/code/session_01CFidRyHPuAWQvuMMotNnu5

---
_Generated by [Claude Code](https://claude.ai/code/session_01CFidRyHPuAWQvuMMotNnu5)_