### PR TITLE
fix(transitions): preserve error chain in MustNew panic

### DIFF
--- a/transitions/config.go
+++ b/transitions/config.go
@@ -52,10 +52,12 @@ func New(config map[string][]string) (*Config, error) {
 }
 
 // MustNew creates a new Transitions instance and panics if there's an error.
+// The panic value is the wrapped error from New, preserving the underlying
+// error chain so callers using recover can inspect it with errors.Is/As.
 func MustNew(config map[string][]string) *Config {
 	t, err := New(config)
 	if err != nil {
-		panic(fmt.Sprintf("failed to create transitions: %v", err))
+		panic(fmt.Errorf("failed to create transitions: %w", err))
 	}
 	return t
 }

--- a/transitions/config.go
+++ b/transitions/config.go
@@ -52,8 +52,9 @@ func New(config map[string][]string) (*Config, error) {
 }
 
 // MustNew creates a new Transitions instance and panics if there's an error.
-// The panic value is the wrapped error from New, preserving the underlying
-// error chain so callers using recover can inspect it with errors.Is/As.
+// The panic value is an error that wraps the error returned by New, so
+// callers using recover can still inspect the underlying cause with
+// errors.Is/As against sentinel values like ErrEmptyConfig.
 func MustNew(config map[string][]string) *Config {
 	t, err := New(config)
 	if err != nil {

--- a/transitions/config_test.go
+++ b/transitions/config_test.go
@@ -245,6 +245,18 @@ func TestMustNew(t *testing.T) {
 			})
 		})
 	})
+
+	t.Run("panic preserves wrapped error chain", func(t *testing.T) {
+		defer func() {
+			r := recover()
+			require.NotNil(t, r)
+			err, ok := r.(error)
+			require.True(t, ok, "panic value must be an error, got %T", r)
+			assert.ErrorIs(t, err, ErrEmptyConfig)
+		}()
+
+		MustNew(map[string][]string{})
+	})
 }
 
 func TestIsTransitionAllowed(t *testing.T) {


### PR DESCRIPTION
## Summary
- `MustNew` previously panicked with `fmt.Sprintf("...: %v", err)`, which flattens the error to a string. Callers using `recover()` lost access to the underlying error and could not use `errors.Is`/`errors.As` against sentinels like `ErrEmptyConfig`.
- This PR panics with the wrapped error itself, preserving the chain.
- Adds a regression test that recovers and asserts `errors.Is(err, ErrEmptyConfig)`.

## Why
Found during a broader audit of the codebase. Tracked as **M5** in the audit report.

## Test plan
- [x] `go test -race -count=1 ./transitions/...`

https://claude.ai/code/session_01CFidRyHPuAWQvuMMotNnu5

---
_Generated by [Claude Code](https://claude.ai/code/session_01CFidRyHPuAWQvuMMotNnu5)_