### PR TITLE
docs(README): correct broadcast timeout default and semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,7 +456,7 @@ machine, _ := fsm.New(
 ```
 
 Timeout values:
-- unspecified: defaults to 100ms timeout-mode (blocks up to 100ms per send, then drops)
+- unspecified: defaults to 100ms timeout-mode (blocks up to 100ms per send, then drops the message if the channel is full)
 - `0`: best-effort delivery (non-blocking; drops immediately if the channel is full)
 - `> 0`: blocks up to the specified duration, then drops the message if the channel is full
 - `< 0`: guaranteed delivery (blocks indefinitely until the message is delivered)

--- a/README.md
+++ b/README.md
@@ -456,9 +456,12 @@ machine, _ := fsm.New(
 ```
 
 Timeout values:
-- `0` or unspecified: uses default of 100ms (best-effort delivery, non-blocking)
-- `> 0`: blocks up to specified duration, then drops message if channel is full
-- `< 0`: guaranteed delivery (blocks indefinitely until message is delivered)
+- unspecified: defaults to 100ms timeout-mode (blocks up to 100ms per send, then drops)
+- `0`: best-effort delivery (non-blocking; drops immediately if the channel is full)
+- `> 0`: blocks up to the specified duration, then drops the message if the channel is full
+- `< 0`: guaranteed delivery (blocks indefinitely until the message is delivered)
+
+> **Note:** broadcasts run inside the post-transition hook chain while the FSM is locked. A slow subscriber stalls every transition for up to the configured timeout, and `< 0` (guaranteed delivery) can stall it indefinitely. Prefer `0` or a finite timeout in production unless you control the consumer.
 
 #### Advanced: Custom Broadcast Manager
 


### PR DESCRIPTION
## Summary
- The README said `"0 or unspecified: uses default of 100ms (best-effort delivery, non-blocking)"`, conflating two different modes:
  - **Unspecified** → 100ms timeout mode (blocks up to 100ms per send, then drops).
  - **Explicit `0`** → best-effort mode (non-blocking; drops immediately).
- This PR splits them into separate bullets and adds a production note that broadcasts run while the FSM is locked, so guaranteed delivery (`< 0`) can stall every transition if a subscriber is slow.

## Why
Found during a broader audit of the codebase. Tracked as **C4** in the audit report.

## Test plan
- [x] No code changes — README only.
- [x] Cross-checked against `fsm.go` (default `broadcastTimeout = 100ms`, dispatched via `broadcast.WithTimeout`) and `hooks/broadcast/manager.go:Broadcast` (timeout `< 0` blocks, `> 0` waits, `== 0` is non-blocking).

https://claude.ai/code/session_01CFidRyHPuAWQvuMMotNnu5

---
_Generated by [Claude Code](https://claude.ai/code/session_01CFidRyHPuAWQvuMMotNnu5)_