### PR TITLE
docs(README): use WithLogger consistently in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,7 +405,7 @@ func main() {
 
 	// 1. Create hooks registry with transitions (required for broadcast support)
 	registry, _ := hooks.NewRegistry(
-		hooks.WithLogHandler(logger.Handler()),
+		hooks.WithLogger(logger),
 		hooks.WithTransitions(transitions.Typical),
 	)
 
@@ -413,7 +413,7 @@ func main() {
 	machine, _ := fsm.New(
 		transitions.StatusNew,
 		transitions.Typical,
-		fsm.WithLogHandler(logger.Handler()),
+		fsm.WithLogger(logger),
 		fsm.WithCallbackRegistry(registry),
 	)
 


### PR DESCRIPTION
## Summary
- Most examples used `WithLogger(logger)`. The "Subscribing to State Changes" block used `WithLogHandler(logger.Handler())` instead.
- Both work, but mixing them in one document leaves readers wondering which is canonical. Standardize on `WithLogger`.

## Why
Found during a broader audit of the codebase. Tracked as **M7** in the audit report.

## Test plan
- [x] No code changes — README only.

https://claude.ai/code/session_01CFidRyHPuAWQvuMMotNnu5

---
_Generated by [Claude Code](https://claude.ai/code/session_01CFidRyHPuAWQvuMMotNnu5)_