### PR TITLE
fix(broadcast): log best-effort drops at Warn

### DIFF
--- a/hooks/broadcast/manager.go
+++ b/hooks/broadcast/manager.go
@@ -124,7 +124,10 @@ func (m *Manager) Broadcast(state string) {
 			case ch <- state:
 				logger.Debug("State delivered to best-effort subscriber")
 			default:
-				logger.Debug("Best-effort subscriber channel full; state delivery skipped",
+				// Promote to Warn for parity with the timeout-mode drop log
+				// below, since silently lost state updates often indicate a
+				// slow consumer that needs investigation.
+				logger.Warn("Best-effort subscriber channel full; state delivery skipped",
 					"channel_capacity", cap(ch), "channel_length", len(ch))
 			}
 		}

--- a/hooks/broadcast/manager.go
+++ b/hooks/broadcast/manager.go
@@ -124,9 +124,9 @@ func (m *Manager) Broadcast(state string) {
 			case ch <- state:
 				logger.Debug("State delivered to best-effort subscriber")
 			default:
-				// Promote to Warn for parity with the timeout-mode drop log
-				// below, since silently lost state updates often indicate a
-				// slow consumer that needs investigation.
+				// Logged at Warn for parity with the timeout-mode drop log
+				// in the branch above: silently lost state updates often
+				// indicate a slow consumer that needs investigation.
 				logger.Warn("Best-effort subscriber channel full; state delivery skipped",
 					"channel_capacity", cap(ch), "channel_length", len(ch))
 			}


### PR DESCRIPTION
## Summary
- Best-effort subscribers (`timeout = 0`) silently dropped messages at `Debug` level. Timeout-mode subscribers already log drops at `Warn` (see line 116 in the same file).
- Promote the best-effort drop log to `Warn` so silent state loss is visible by default — it usually means a consumer is too slow.
- The success path still logs at `Debug` to avoid noise on healthy subscribers.

## Why
Found during a broader audit of the codebase. Tracked as **M9** in the audit report.

## Test plan
- [x] `go test -race -count=1 ./hooks/broadcast/...`

https://claude.ai/code/session_01CFidRyHPuAWQvuMMotNnu5

---
_Generated by [Claude Code](https://claude.ai/code/session_01CFidRyHPuAWQvuMMotNnu5)_