### PR TITLE
fix(transitions): sort GetAllowedTransitions output

### DIFF
--- a/transitions/config.go
+++ b/transitions/config.go
@@ -70,8 +70,9 @@ func (t *Config) IsTransitionAllowed(from, to string) bool {
 	return exists
 }
 
-// GetAllowedTransitions returns all allowed target states from a given source state.
-// Returns the slice of target states and a boolean indicating if the source state exists.
+// GetAllowedTransitions returns all allowed target states from a given source
+// state, sorted alphabetically. Returns the slice of target states and a
+// boolean indicating if the source state exists.
 func (t *Config) GetAllowedTransitions(from string) ([]string, bool) {
 	targetsMap, ok := t.index[from]
 	if !ok {
@@ -82,6 +83,7 @@ func (t *Config) GetAllowedTransitions(from string) ([]string, bool) {
 	for target := range targetsMap {
 		targets = append(targets, target)
 	}
+	slices.Sort(targets)
 	return targets, true
 }
 

--- a/transitions/config_test.go
+++ b/transitions/config_test.go
@@ -295,6 +295,19 @@ func TestGetAllowedTransitions(t *testing.T) {
 		assert.False(t, ok)
 		assert.Nil(t, targets)
 	})
+
+	t.Run("returns targets in sorted order", func(t *testing.T) {
+		trans := MustNew(map[string][]string{
+			"src": {"zulu", "alpha", "mike", "bravo"},
+			"alpha": {},
+			"bravo": {},
+			"mike":  {},
+			"zulu":  {},
+		})
+		targets, ok := trans.GetAllowedTransitions("src")
+		require.True(t, ok)
+		assert.Equal(t, []string{"alpha", "bravo", "mike", "zulu"}, targets)
+	})
 }
 
 func TestHasState(t *testing.T) {


### PR DESCRIPTION
## Summary
- Map iteration order in Go is non-deterministic, so each call to `GetAllowedTransitions` returned a slice in a different order.
- `GetAllStates` already sorts its output. This change brings `GetAllowedTransitions` into line, so the package's enumeration APIs are uniformly deterministic.
- Adds a regression test asserting alphabetical order.

## Why
Found during a broader audit of the codebase. Tracked as **M6** in the audit report.

## Test plan
- [x] `go test -race -count=1 ./transitions/...`

https://claude.ai/code/session_01CFidRyHPuAWQvuMMotNnu5

---
_Generated by [Claude Code](https://claude.ai/code/session_01CFidRyHPuAWQvuMMotNnu5)_