### PR TITLE
perf(fsm): drop redundant RLock from GetAllStates

### DIFF
--- a/fsm.go
+++ b/fsm.go
@@ -48,6 +48,14 @@ import (
 	"github.com/robbyt/go-fsm/v2/transitions"
 )
 
+// transitionDB is the contract a transition table must satisfy.
+//
+// Implementations MUST be safe for concurrent reads from multiple goroutines.
+// The Machine does not guard transitionDB calls with its mutex
+// (GetAllStates, HasState, IsTransitionAllowed all run lock-free), so any
+// locking or copying needed for read safety is the implementation's
+// responsibility. The bundled transitions.Config satisfies this contract:
+// its index is built once at construction and never mutated.
 type transitionDB interface {
 	HasState(state string) bool
 	GetAllStates() []string

--- a/fsm.go
+++ b/fsm.go
@@ -149,9 +149,11 @@ func (fsm *Machine) GetState() string {
 }
 
 // GetAllStates returns all allowed states that have been added to this FSM.
+//
+// The transition table is set at construction and not mutated, so this method
+// does not take the FSM mutex. Callers passing a custom transitionDB
+// implementation must ensure their type is safe for concurrent reads.
 func (fsm *Machine) GetAllStates() []string {
-	fsm.mutex.RLock()
-	defer fsm.mutex.RUnlock()
 	return fsm.transitions.GetAllStates()
 }
 

--- a/fsm_test.go
+++ b/fsm_test.go
@@ -470,6 +470,44 @@ func TestFSM_Concurrency(t *testing.T) {
 		finalState := fsm.GetState()
 		assert.Contains(t, []string{"state1", "state2"}, finalState)
 	})
+
+	t.Run("GetAllStates races with Transition", func(t *testing.T) {
+		// Regression: GetAllStates used to take the FSM's RLock. The lock was
+		// removed because the bundled transitions.Config is immutable after
+		// construction. This test asserts that running GetAllStates
+		// concurrently with Transition is race-detector clean and never
+		// returns a malformed slice.
+		fsm, err := NewSimple("state1", map[string][]string{
+			"state1": {"state2"},
+			"state2": {"state1"},
+		})
+		require.NoError(t, err)
+
+		expected := []string{"state1", "state2"}
+
+		var wg sync.WaitGroup
+		for range 50 {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for range 20 {
+					states := fsm.GetAllStates()
+					assert.ElementsMatch(t, expected, states)
+				}
+			}()
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for range 20 {
+					//nolint:errcheck // racing for safety, not correctness
+					_ = fsm.Transition("state2")
+					//nolint:errcheck
+					_ = fsm.Transition("state1")
+				}
+			}()
+		}
+		wg.Wait()
+	})
 }
 
 func TestFSM_Options(t *testing.T) {


### PR DESCRIPTION
## Summary
- The transition table (`transitionDB`) is injected at construction and never mutated by the `Machine`. `GetAllStates` therefore did not need the FSM mutex at all — the lock just added contention with `Transition` calls.
- Drops the lock and documents the implicit contract (custom `transitionDB` implementations must be safe for concurrent reads — already true for the bundled `transitions.Config`).

## Why
Found during a broader audit of the codebase. Tracked as **M1** in the audit report.

## Test plan
- [x] `go test -race -count=1 ./...`

https://claude.ai/code/session_01CFidRyHPuAWQvuMMotNnu5

---
_Generated by [Claude Code](https://claude.ai/code/session_01CFidRyHPuAWQvuMMotNnu5)_