### PR TITLE
perf(broadcast): cache the Manager logger once at construction

### DIFF
--- a/hooks/broadcast/manager.go
+++ b/hooks/broadcast/manager.go
@@ -29,7 +29,7 @@ import (
 type Manager struct {
 	mu          sync.Mutex
 	subscribers sync.Map
-	logger      slog.Handler
+	logger      *slog.Logger
 }
 
 // NewManager creates a new broadcast manager.
@@ -38,7 +38,7 @@ func NewManager(handler slog.Handler) *Manager {
 		handler = slog.Default().Handler()
 	}
 	return &Manager{
-		logger: handler,
+		logger: slog.New(handler.WithGroup("broadcast")),
 	}
 }
 
@@ -96,7 +96,7 @@ func (m *Manager) GetStateChan(ctx context.Context, opts ...Option) (<-chan stri
 // - timeout < 0: blocks indefinitely until delivered (guaranteed delivery)
 // The mutex ensures broadcasts are always serial to maintain consistent ordering.
 func (m *Manager) Broadcast(state string) {
-	logger := slog.New(m.logger.WithGroup("broadcast")).With("state", state)
+	logger := m.logger.With("state", state)
 
 	// Lock during the entire broadcast to ensure all subscribers receive broadcasts
 	// in the same order, preventing race conditions where concurrent broadcasts
@@ -181,7 +181,7 @@ func (m *Manager) iterSubscribers() iter.Seq2[chan string, *Config] {
 
 			config, ok := value.(*Config)
 			if !ok {
-				slog.New(m.logger).Error("Invalid subscriber config type; skipping subscriber")
+				m.logger.Error("Invalid subscriber config type; skipping subscriber")
 				return true
 			}
 


### PR DESCRIPTION
## Summary
- `Broadcast()` previously built a fresh `slog.Logger` on every invocation (`slog.New(m.logger.WithGroup("broadcast"))`), and `iterSubscribers` did the same on every type-mismatch error path.
- Build the grouped logger once in `NewManager` and reuse it.
- The `Manager.logger` field type changes from `slog.Handler` to `*slog.Logger`. The field is unexported so this is purely internal.

This follows the repo's existing convention: `fsm.Machine` and `hooks.Registry` both accept a `slog.Handler` at the boundary, wrap it once with `slog.New(...)`, and store a `*slog.Logger` internally (cf. `WithLogHandler`, and Machine's default `slog.New(...WithGroup("fsm"))`). `NewManager(handler slog.Handler)` keeps the `slog.Handler` interface at the public boundary and instantiates the `*slog.Logger` internally.

## Why
Found during a broader audit of the codebase. Tracked as **L9** in the audit report.

## Test plan
- [x] `go test -race -count=1 ./...`
- [x] `golangci-lint run ./...` — 0 issues
- Rebased onto current `main` (post #67/#72 broadcast changes) — clean apply.

https://claude.ai/code/session_01CFidRyHPuAWQvuMMotNnu5

---
_Generated by [Claude Code](https://claude.ai/code/session_01CFidRyHPuAWQvuMMotNnu5)_