### PR TITLE
fix(fsm): use comma-ok type assertion in GetState

### DIFF
--- a/fsm.go
+++ b/fsm.go
@@ -144,8 +144,14 @@ func NewSimple(
 }
 
 // GetState returns the current state of the finite state machine.
+//
+// Safety: state is only ever written by setState/Store with a string value,
+// so the assertion below cannot fail in practice. Use the comma-ok form
+// anyway so a future regression that stores a non-string (or queries before
+// the initial Store) returns "" instead of panicking.
 func (fsm *Machine) GetState() string {
-	return fsm.state.Load().(string)
+	v, _ := fsm.state.Load().(string)
+	return v
 }
 
 // GetAllStates returns all allowed states that have been added to this FSM.

--- a/fsm.go
+++ b/fsm.go
@@ -145,10 +145,13 @@ func NewSimple(
 
 // GetState returns the current state of the finite state machine.
 //
-// Safety: state is only ever written by setState/Store with a string value,
-// so the assertion below cannot fail in practice. Use the comma-ok form
-// anyway so a future regression that stores a non-string (or queries before
-// the initial Store) returns "" instead of panicking.
+// Safety: setState only stores strings, and atomic.Value would already
+// panic at Store-time on a type mismatch, so the assertion below cannot
+// fail in practice. The comma-ok form is used to defend against the only
+// remaining edge case — a Load on a Machine constructed without going
+// through New (zero-value, no initial Store), which returns nil from
+// Load and would otherwise panic on the assertion. In that case the
+// caller observes "" rather than a runtime panic.
 func (fsm *Machine) GetState() string {
 	v, _ := fsm.state.Load().(string)
 	return v

--- a/fsm_test.go
+++ b/fsm_test.go
@@ -165,6 +165,19 @@ func TestFSM_GetState(t *testing.T) {
 	assert.Equal(t, "initial", fsm.GetState())
 }
 
+// TestFSM_GetState_ZeroValue verifies the comma-ok type assertion in
+// GetState handles a zero-value Machine (atomic.Value.Load returns nil)
+// without panicking. Constructing a Machine outside New() is not part of
+// the public API, but this defends against accidental misuse.
+func TestFSM_GetState_ZeroValue(t *testing.T) {
+	t.Parallel()
+
+	var fsm Machine
+	assert.NotPanics(t, func() {
+		assert.Equal(t, "", fsm.GetState())
+	})
+}
+
 func TestFSM_SetState(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- The `state` field is internal and only ever stored as a string by `setState`/`Store`, so today the unchecked assertion `fsm.state.Load().(string)` cannot fail.
- Switch to the comma-ok form so future regressions (a non-string Store, or a Load before the initial Store) return `""` instead of panicking.

## Why
Found during a broader audit of the codebase. Tracked as **L8** in the audit report.

## Test plan
- [x] `go test -race -count=1 ./...`

https://claude.ai/code/session_01CFidRyHPuAWQvuMMotNnu5

---
_Generated by [Claude Code](https://claude.ai/code/session_01CFidRyHPuAWQvuMMotNnu5)_