### PR TITLE
feat(transitions): add Config.IsTerminal helper

### DIFF
--- a/transitions/config.go
+++ b/transitions/config.go
@@ -91,6 +91,17 @@ func (t *Config) HasState(state string) bool {
 	return ok
 }
 
+// IsTerminal reports whether the given state has no outgoing transitions.
+// Returns true only if the state is defined and its allowed-targets set is
+// empty. Unknown states return false.
+func (t *Config) IsTerminal(state string) bool {
+	targets, ok := t.index[state]
+	if !ok {
+		return false
+	}
+	return len(targets) == 0
+}
+
 // GetAllStates returns all source/target states defined in the transitions configuration, and
 // returns an alphabetically sorted slice.
 func (t *Config) GetAllStates() []string {

--- a/transitions/config_test.go
+++ b/transitions/config_test.go
@@ -297,6 +297,29 @@ func TestGetAllowedTransitions(t *testing.T) {
 	})
 }
 
+func TestIsTerminal(t *testing.T) {
+	t.Parallel()
+
+	trans := MustNew(map[string][]string{
+		"running":  {"stopped", "error"},
+		"stopped":  {},
+		"error":    {},
+	})
+
+	t.Run("returns true for terminal state", func(t *testing.T) {
+		assert.True(t, trans.IsTerminal("stopped"))
+		assert.True(t, trans.IsTerminal("error"))
+	})
+
+	t.Run("returns false for non-terminal state", func(t *testing.T) {
+		assert.False(t, trans.IsTerminal("running"))
+	})
+
+	t.Run("returns false for unknown state", func(t *testing.T) {
+		assert.False(t, trans.IsTerminal("nope"))
+	})
+}
+
 func TestHasState(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Detecting terminal states via `len(GetAllowedTransitions(...)) == 0` worked but allocated a slice on every call and was awkward.
- Add a direct `Config.IsTerminal(state string) bool` helper. For unknown states it returns `false`, matching `HasState`'s "unknown == false" convention.

## Why
Found during a broader audit of the codebase. Tracked as **L4** in the audit report.

## Test plan
- [x] `go test -race -count=1 ./transitions/...`

https://claude.ai/code/session_01CFidRyHPuAWQvuMMotNnu5

---
_Generated by [Claude Code](https://claude.ai/code/session_01CFidRyHPuAWQvuMMotNnu5)_