### PR TITLE
fix(hooks): clone hook slice before in-place delete to fix data race

### DIFF
--- a/hooks/registry.go
+++ b/hooks/registry.go
@@ -66,12 +66,18 @@ type hookEntry struct {
 
 // removeFrom removes this hookEntry from the given slice and returns the new slice.
 //
-// The slice is cloned before deletion so the original backing array is never
-// mutated in place. Hook executors snapshot the index slices under RLock and
-// then iterate after releasing the lock; deleting in place (and a later append
-// reusing the freed slot) would write to elements those snapshots are still
-// reading, causing a data race and potential nil-entry dereference.
+// When the entry is present, the slice is cloned before deletion so the
+// original backing array is never mutated in place. Hook executors snapshot the
+// index slices under RLock and then iterate after releasing the lock; deleting
+// in place (and a later append reusing the freed slot) would write to elements
+// those snapshots are still reading, causing a data race and potential
+// nil-entry dereference. When the entry is absent the slice is returned
+// unchanged, avoiding a needless allocation for every transition key that
+// RemoveHook scans.
 func (e *hookEntry) removeFrom(slice []*hookEntry) []*hookEntry {
+	if !slices.Contains(slice, e) {
+		return slice
+	}
 	return slices.DeleteFunc(slices.Clone(slice), func(entry *hookEntry) bool {
 		return entry == e
 	})

--- a/hooks/registry.go
+++ b/hooks/registry.go
@@ -65,8 +65,14 @@ type hookEntry struct {
 }
 
 // removeFrom removes this hookEntry from the given slice and returns the new slice.
+//
+// The slice is cloned before deletion so the original backing array is never
+// mutated in place. Hook executors snapshot the index slices under RLock and
+// then iterate after releasing the lock; deleting in place (and a later append
+// reusing the freed slot) would write to elements those snapshots are still
+// reading, causing a data race and potential nil-entry dereference.
 func (e *hookEntry) removeFrom(slice []*hookEntry) []*hookEntry {
-	return slices.DeleteFunc(slice, func(entry *hookEntry) bool {
+	return slices.DeleteFunc(slices.Clone(slice), func(entry *hookEntry) bool {
 		return entry == e
 	})
 }

--- a/hooks/registry_test.go
+++ b/hooks/registry_test.go
@@ -1140,7 +1140,10 @@ func TestRemoveHookConcurrentExecuteNoRace(t *testing.T) {
 			case <-stop:
 				return
 			default:
-				_ = reg.ExecutePreTransitionHooks(context.Background(), "a", "b")
+				if err := reg.ExecutePreTransitionHooks(context.Background(), "a", "b"); err != nil {
+					t.Errorf("unexpected hook error: %v", err)
+					return
+				}
 			}
 		}
 	}()

--- a/hooks/registry_test.go
+++ b/hooks/registry_test.go
@@ -1147,6 +1147,13 @@ func TestRemoveHookConcurrentExecuteNoRace(t *testing.T) {
 			}
 		}
 	}()
+	// Always stop and join the executor goroutine, even if a require below
+	// fails early via FailNow, so it can't outlive the test and log after
+	// completion or interfere with later tests.
+	t.Cleanup(func() {
+		close(stop)
+		wg.Wait()
+	})
 
 	for i := 0; i < 2000; i++ {
 		name := fmt.Sprintf("churn-%d", i)
@@ -1160,6 +1167,4 @@ func TestRemoveHookConcurrentExecuteNoRace(t *testing.T) {
 		}))
 		require.NoError(t, reg.RemoveHook(name))
 	}
-	close(stop)
-	wg.Wait()
 }

--- a/hooks/registry_test.go
+++ b/hooks/registry_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sync"
 	"testing"
 
 	"github.com/robbyt/go-fsm/v2/transitions"
@@ -1107,4 +1108,55 @@ func TestRegisterHookValidation(t *testing.T) {
 		require.ErrorIs(t, err, ErrHookNameAlreadyExists)
 		assert.Contains(t, err.Error(), "test-duplicate-post-name")
 	})
+}
+
+// TestRemoveHookConcurrentExecuteNoRace exercises RemoveHook and
+// RegisterPreTransitionHook churning the same transition's index slice while a
+// separate goroutine executes hooks for that transition. Before removeFrom was
+// changed to clone-before-delete, in-place deletion plus a later append reusing
+// the freed slot raced with (and could nil-deref) the lock-free executor
+// snapshot. Run under -race to detect regressions.
+func TestRemoveHookConcurrentExecuteNoRace(t *testing.T) {
+	reg, err := NewRegistry()
+	require.NoError(t, err)
+
+	// A permanent hook keeps the transition's index slice non-empty at index 0.
+	require.NoError(t, reg.RegisterPreTransitionHook(PreTransitionHookConfig{
+		Name: "permanent",
+		From: []string{"a"},
+		To:   []string{"b"},
+		Guard: func(ctx context.Context, from, to string) error {
+			return nil
+		},
+	}))
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				_ = reg.ExecutePreTransitionHooks(context.Background(), "a", "b")
+			}
+		}
+	}()
+
+	for i := 0; i < 2000; i++ {
+		name := fmt.Sprintf("churn-%d", i)
+		require.NoError(t, reg.RegisterPreTransitionHook(PreTransitionHookConfig{
+			Name: name,
+			From: []string{"a"},
+			To:   []string{"b"},
+			Guard: func(ctx context.Context, from, to string) error {
+				return nil
+			},
+		}))
+		require.NoError(t, reg.RemoveHook(name))
+	}
+	close(stop)
+	wg.Wait()
 }


### PR DESCRIPTION
## Problem

`RemoveHook` removed entries with `slices.DeleteFunc` operating directly on the shared index/wildcard slices (`hookEntry.removeFrom`). That shifts and zeroes the backing array **in place**, and a subsequent `Register*` appends into the freed slot of that same array. Hook executors (`ExecutePre/PostTransitionHooks`) snapshot those slices under `RLock` and iterate **after** releasing the lock, so a concurrent remove+register raced with the executor — confirmed by `go test -race` (append write at `registry.go` vs executor read). Worst case, the executor reads a zeroed `nil *hookEntry` and panics dereferencing it *outside* `safeCallGuard`'s recover, crashing the process.

## Fix

`removeFrom` now clones the slice before deleting:

```go
return slices.DeleteFunc(slices.Clone(slice), func(entry *hookEntry) bool {
    return entry == e
})
```

In-flight reader snapshots reference the old backing array, which is never mutated. A later `append` therefore writes into the fresh cloned array, not the one a reader is iterating. Appends on their own were already safe (readers never index past their snapshot length); only the in-place deletion was unsafe.

## Tests

Added `TestRemoveHookConcurrentExecuteNoRace`, which churns `Register`/`RemoveHook` on one transition while a separate goroutine executes hooks for it. Verified it reports `WARNING: DATA RACE` without the fix and passes with it under `go test -race`.

fixes #57

---
_Generated by [Claude Code](https://claude.ai/code/session_01MxceLKgW8yjqdvroh6GxJ5)_