### PR TITLE
style: fix pre-existing lint failures on main

### DIFF
--- a/fsm_test.go
+++ b/fsm_test.go
@@ -174,7 +174,7 @@ func TestFSM_GetState_ZeroValue(t *testing.T) {
 
 	var fsm Machine
 	assert.NotPanics(t, func() {
-		assert.Equal(t, "", fsm.GetState())
+		assert.Empty(t, fsm.GetState())
 	})
 }
 

--- a/transitions/config_test.go
+++ b/transitions/config_test.go
@@ -310,7 +310,7 @@ func TestGetAllowedTransitions(t *testing.T) {
 
 	t.Run("returns targets in sorted order", func(t *testing.T) {
 		trans := MustNew(map[string][]string{
-			"src": {"zulu", "alpha", "mike", "bravo"},
+			"src":   {"zulu", "alpha", "mike", "bravo"},
 			"alpha": {},
 			"bravo": {},
 			"mike":  {},
@@ -326,9 +326,9 @@ func TestIsTerminal(t *testing.T) {
 	t.Parallel()
 
 	trans := MustNew(map[string][]string{
-		"running":  {"stopped", "error"},
-		"stopped":  {},
-		"error":    {},
+		"running": {"stopped", "error"},
+		"stopped": {},
+		"error":   {},
 	})
 
 	t.Run("returns true for terminal state", func(t *testing.T) {


### PR DESCRIPTION
## Problem

CI runs `golangci-lint` at `version: latest` (currently 2.12.2), which is stricter than the code on `main` was written against. Two issues currently fail the lint check on `main` itself, which means **every** PR branched off `main` inherits a red lint check unrelated to its own changes:

- `transitions/config_test.go` — map literal keys not column-aligned (gofmt/gci formatter)
- `fsm_test.go:177` — `assert.Equal(t, "", fsm.GetState())` should be `assert.Empty(...)` (testifylint)

## Fix

- Ran the project formatters (`golangci-lint fmt`) to align the map literals in `config_test.go`.
- Replaced `assert.Equal(t, "", ...)` with `assert.Empty(t, ...)` in `fsm_test.go`.

No production code changes — test-only formatting/assertion fixes.

## Verification

- `golangci-lint run ./...` → `0 issues`
- `go test -race ./...` → all packages pass

Landing this on `main` first unblocks the lint check for the in-flight security/correctness fix PRs (#64 and the rest of #57–#63).

> Note: CI pins `version: latest` for golangci-lint, so the toolchain will keep drifting and may surface new nits on future linter releases. Pinning to a fixed version is worth considering separately, but is out of scope here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MxceLKgW8yjqdvroh6GxJ5)_