### PR TITLE
fix(broadcast): abort blocking sends when a subscriber's context is cancelled

### DIFF
--- a/hooks/broadcast/manager.go
+++ b/hooks/broadcast/manager.go
@@ -57,6 +57,10 @@ func (m *Manager) GetStateChan(ctx context.Context, opts ...Option) (<-chan stri
 		opt(config)
 	}
 
+	// Record the subscriber's cancellation signal so Broadcast can abandon a
+	// blocking send once this subscriber's context is cancelled.
+	config.done = ctx.Done()
+
 	var ch chan string
 	if config.channel != nil {
 		ch = config.channel
@@ -99,11 +103,22 @@ func (m *Manager) Broadcast(state string) {
 	var wg sync.WaitGroup
 
 	for ch, config := range m.iterSubscribers() {
+		// done is the subscriber's context cancellation signal. Selecting on it
+		// in the blocking branches ensures a subscriber that has gone away (its
+		// context was cancelled) cannot block the broadcast indefinitely while
+		// the manager mutex is held, which would otherwise deadlock unsubscribe
+		// and every future Broadcast.
+		done := config.done
 		if config.timeout < 0 {
-			// Negative timeout: block indefinitely (guaranteed delivery)
+			// Negative timeout: block until delivered or the subscriber departs
+			// (guaranteed delivery for live subscribers).
 			wg.Go(func() {
-				ch <- state
-				logger.Debug("State delivered to guaranteed delivery subscriber")
+				select {
+				case ch <- state:
+					logger.Debug("State delivered to guaranteed delivery subscriber")
+				case <-done:
+					logger.Debug("Guaranteed-delivery subscriber departed before delivery; aborting send")
+				}
 			})
 		} else if config.timeout > 0 {
 			// Positive timeout: block up to timeout duration
@@ -112,6 +127,8 @@ func (m *Manager) Broadcast(state string) {
 				select {
 				case ch <- state:
 					logger.Debug("State delivered to timeout subscriber")
+				case <-done:
+					logger.Debug("Timeout subscriber departed before delivery; aborting send")
 				case <-time.After(timeout):
 					logger.Warn("Timeout subscriber blocked; state delivery timed out",
 						"timeout", timeout,

--- a/hooks/broadcast/manager_test.go
+++ b/hooks/broadcast/manager_test.go
@@ -511,3 +511,61 @@ func TestGetStateChan_CustomChannelNotClosedOnContextCancel(t *testing.T) {
 	// Clean up: close the custom channel since we own it
 	close(customCh)
 }
+
+// TestBroadcast_CancelledGuaranteedSubscriberDoesNotDeadlock verifies that a
+// guaranteed-delivery subscriber (timeout < 0) that has stopped reading cannot
+// permanently wedge the manager. Before Broadcast selected on the subscriber's
+// context cancellation, a full, unread guaranteed-delivery channel blocked
+// Broadcast forever while holding the manager mutex, so cancelling the
+// subscriber could never unsubscribe it and every future Broadcast deadlocked.
+func TestBroadcast_CancelledGuaranteedSubscriberDoesNotDeadlock(t *testing.T) {
+	t.Parallel()
+
+	manager := broadcast.NewManager(newTestLogger().Handler())
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	// Guaranteed delivery, default buffer size 1; nobody ever reads from ch.
+	_, err := manager.GetStateChan(ctx, broadcast.WithTimeout(-1))
+	require.NoError(t, err)
+
+	// Fill the single-slot buffer so the next send has nowhere to go.
+	manager.Broadcast("first")
+
+	// A second broadcast blocks in the guaranteed-delivery send: the channel is
+	// full and unread, so Broadcast holds the manager mutex and does not return.
+	broadcastReturned := make(chan struct{})
+	go func() {
+		manager.Broadcast("second")
+		close(broadcastReturned)
+	}()
+
+	// Confirm it is actually blocked before we cancel.
+	select {
+	case <-broadcastReturned:
+		t.Fatal("Broadcast returned before its send could block; test precondition not met")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	// Cancelling the subscriber must let the blocked send abort, releasing the
+	// mutex and allowing Broadcast to return.
+	cancel()
+	select {
+	case <-broadcastReturned:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Broadcast deadlocked: a cancelled guaranteed-delivery subscriber blocked it forever")
+	}
+
+	// The manager must remain usable after the dead subscriber is gone.
+	readerCtx, readerCancel := context.WithCancel(context.Background())
+	t.Cleanup(readerCancel)
+	got, err := manager.GetStateChan(readerCtx, broadcast.WithBufferSize(1))
+	require.NoError(t, err)
+	manager.Broadcast("third")
+	select {
+	case state := <-got:
+		assert.Equal(t, "third", state)
+	case <-time.After(time.Second):
+		t.Fatal("manager wedged: a fresh subscriber received no broadcast after the deadlock scenario")
+	}
+}

--- a/hooks/broadcast/options.go
+++ b/hooks/broadcast/options.go
@@ -26,6 +26,11 @@ type Config struct {
 	channel         chan string
 	externalChannel bool
 	timeout         time.Duration
+	// done is the subscriber's context cancellation signal, set by
+	// Manager.GetStateChan. Broadcast selects on it so a blocking send to a
+	// subscriber whose context has been cancelled is abandoned instead of
+	// holding the manager mutex forever.
+	done <-chan struct{}
 }
 
 // WithBufferSize creates a new internal channel with the specified buffer size.


### PR DESCRIPTION
## Problem

`broadcast.Manager.Broadcast` holds `m.mu` for the entire send phase including `wg.Wait()`. A `timeout < 0` (guaranteed delivery) subscriber that stops reading blocks its send forever **while the mutex is held**. `unsubscribe` — the context-cancel cleanup path — also needs `m.mu`, so cancelling the subscriber's context can never rescue it. Since the broadcast hook runs inside `Machine.transition` under the FSM write lock, one stuck subscriber permanently wedges the entire machine: every subsequent `Transition`/`SetState` blocks forever.

## Fix

Capture each subscriber's `ctx.Done()` in its broadcast `Config` (set in `GetStateChan`) and `select` on it in the blocking send branches:

```go
done := config.done
// guaranteed delivery (timeout < 0)
select {
case ch <- state:
case <-done: // subscriber departed; abort the send
}
```

The timeout branch gains the same `<-done` case; best-effort (timeout == 0) is already non-blocking and unchanged. A departed subscriber now aborts its send, `wg.Wait` returns, `m.mu` is released, and `unsubscribe` proceeds. Guaranteed delivery still blocks for **live** subscribers, preserving the documented contract — only the post-cancellation deadlock is removed. Close-after-unsubscribe ordering stays safe because `unsubscribe` still serializes on `m.mu`.

## Tests

`TestBroadcast_CancelledGuaranteedSubscriberDoesNotDeadlock`: fills a guaranteed-delivery subscriber's buffer, starts a second broadcast that blocks on the full channel, cancels the subscriber, and asserts the broadcast returns (and the manager remains usable). Verified it **times out / deadlocks without the fix** and passes with it, under `go test -race`.

Fixes #58

---
_Generated by [Claude Code](https://claude.ai/code/session_01MxceLKgW8yjqdvroh6GxJ5)_