### PR TITLE
fix(transitions): deep-copy input map in New to prevent aliasing

### DIFF
--- a/transitions/config.go
+++ b/transitions/config.go
@@ -40,13 +40,23 @@ func New(config map[string][]string) (*Config, error) {
 		return nil, ErrEmptyConfig
 	}
 
-	index, err := buildIndex(config)
+	// Deep-copy the caller's map before storing it. Without this, later
+	// mutations to the passed-in map would desynchronize the stored config
+	// (read by GetAllStates/AsMap/MarshalJSON) from the validated index (read
+	// by HasState/IsTransitionAllowed), and concurrent mutation by the caller
+	// would race with reads.
+	stored := maps.Clone(config)
+	for from, tos := range stored {
+		stored[from] = slices.Clone(tos)
+	}
+
+	index, err := buildIndex(stored)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrInvalidConfig, err)
 	}
 
 	return &Config{
-		config: config,
+		config: stored,
 		index:  index,
 	}, nil
 }

--- a/transitions/config_test.go
+++ b/transitions/config_test.go
@@ -747,3 +747,36 @@ func TestJSONRoundTrip(t *testing.T) {
 		assert.ElementsMatch(t, Typical.GetAllStates(), restored.GetAllStates())
 	})
 }
+
+// TestNew_DeepCopiesInput verifies that New snapshots the caller's map so that
+// later mutations to it cannot desynchronize the stored config from the
+// validated index. Before New deep-copied its input, adding/removing entries
+// in the caller's map after construction leaked into GetAllStates/AsMap (which
+// read the stored config) while HasState/IsTransitionAllowed (which read the
+// index) disagreed.
+func TestNew_DeepCopiesInput(t *testing.T) {
+	t.Parallel()
+
+	input := map[string][]string{
+		"online":  {"offline"},
+		"offline": {"online"},
+	}
+	cfg, err := New(input)
+	require.NoError(t, err)
+
+	// Mutate the caller's map (and an inner slice) after construction.
+	input["evil"] = []string{"online"}
+	input["online"] = append(input["online"], "evil")
+	delete(input, "offline")
+
+	// The Config must reflect the original snapshot, not the mutations.
+	assert.False(t, cfg.HasState("evil"), "injected state must not appear")
+	assert.NotContains(t, cfg.GetAllStates(), "evil", "GetAllStates must not see post-construction mutations")
+	assert.True(t, cfg.HasState("offline"), "deleted state must still be present")
+	assert.False(t, cfg.IsTransitionAllowed("online", "evil"), "injected transition must not be allowed")
+
+	// AsMap must also be free of the injected entries.
+	m := cfg.AsMap()
+	assert.NotContains(t, m, "evil")
+	assert.NotContains(t, m["online"], "evil")
+}


### PR DESCRIPTION
## Problem

`transitions.New` stored the caller's `map[string][]string` by reference. Mutating that map after construction desynchronized the stored config (read by `GetAllStates`, `AsMap`, `MarshalJSON`) from the validated index (read by `HasState`, `IsTransitionAllowed`). A serialized machine could round-trip into a state graph that was never validated, and concurrent mutation by the caller was a straight data race.

## Fix

`New` now deep-copies the input — outer map via `maps.Clone`, inner target slices via `slices.Clone` — before building the index and storing it. This is the same pattern `AsMap` already uses for its output. The `Config` is now fully isolated from the caller's map.

## Tests

`TestNew_DeepCopiesInput`: after constructing a `Config`, mutates the caller's map (adds an `evil` state and transition, deletes an existing state) and asserts the `Config` still reflects the original snapshot across `HasState`, `IsTransitionAllowed`, `GetAllStates`, and `AsMap`. Verified it fails without the fix and passes with it.

Fixes #59

---
_Generated by [Claude Code](https://claude.ai/code/session_01MxceLKgW8yjqdvroh6GxJ5)_