### PR TITLE
fix(fsm): make GetStateChan subscribe + initial send atomic

### DIFF
--- a/fsm.go
+++ b/fsm.go
@@ -315,6 +315,13 @@ func (fsm *Machine) transition(ctx context.Context, toState string) error {
 // the current state immediately, blocking on sending the initial state if the channel buffer is full.
 // Use a buffered channel to avoid blocking.
 //
+// Subscriber registration and the initial-state send happen while holding the FSM read lock, so they
+// are atomic with respect to transitions. Two consequences follow: GetStateChan must NOT be called
+// from within a transition hook (the hook already holds the FSM write lock, so this would deadlock),
+// and a full or unbuffered channel blocks transitions until the initial send drains. The initial
+// send honors the provided context — if ctx is cancelled while it is blocked, GetStateChan returns
+// the context's error.
+//
 // This method requires the FSM to be configured with a hooks.Registry (via WithCallbackRegistry).
 // The registry must be created with WithTransitions() to support wildcard pattern matching.
 // Returns an error if the callback executor does not support dynamic hook registration.
@@ -411,13 +418,9 @@ func (fsm *Machine) GetStateChan(ctx context.Context, c chan string) error {
 	// hook runs inside transition()), so the read lock guarantees no transition
 	// can broadcast between registering the channel and sending the initial
 	// state. Without it, a concurrent transition could make the subscriber
-	// observe a duplicated or out-of-order first value. Concurrent
-	// GetStateChan callers still proceed in parallel under the shared read lock.
-	//
-	// Note: the initial send happens under the read lock, so a full or
-	// unbuffered channel blocks transitions until it drains — use a buffered
-	// channel (see the method doc). For the same reason, GetStateChan must not
-	// be called from within a transition hook, which already holds the write lock.
+	// observe a duplicated or out-of-order first value. Concurrent GetStateChan
+	// callers still proceed in parallel under the shared read lock. (See the
+	// method doc for the blocking and hook-reentrancy implications.)
 	fsm.mutex.RLock()
 	defer fsm.mutex.RUnlock()
 
@@ -430,7 +433,15 @@ func (fsm *Machine) GetStateChan(ctx context.Context, c chan string) error {
 		return fmt.Errorf("failed to register channel: %w", err)
 	}
 
-	c <- fsm.GetState()
+	// Honor the context during the initial send so a full/unbuffered channel
+	// cannot block here (and thus block transitions, since we hold the read
+	// lock) past the caller's cancellation. The subscriber is unsubscribed by
+	// the same ctx cancellation via the broadcast manager's cleanup goroutine.
+	select {
+	case c <- fsm.GetState():
+	case <-ctx.Done():
+		return fmt.Errorf("state channel registration canceled: %w", ctx.Err())
+	}
 
 	return nil
 }

--- a/fsm.go
+++ b/fsm.go
@@ -406,6 +406,21 @@ func (fsm *Machine) GetStateChan(ctx context.Context, c chan string) error {
 		return fsm.stateChanSetupErr
 	}
 
+	// Register the subscriber and send the current state while holding the read
+	// lock. Broadcasts only happen under the write lock (the post-transition
+	// hook runs inside transition()), so the read lock guarantees no transition
+	// can broadcast between registering the channel and sending the initial
+	// state. Without it, a concurrent transition could make the subscriber
+	// observe a duplicated or out-of-order first value. Concurrent
+	// GetStateChan callers still proceed in parallel under the shared read lock.
+	//
+	// Note: the initial send happens under the read lock, so a full or
+	// unbuffered channel blocks transitions until it drains — use a buffered
+	// channel (see the method doc). For the same reason, GetStateChan must not
+	// be called from within a transition hook, which already holds the write lock.
+	fsm.mutex.RLock()
+	defer fsm.mutex.RUnlock()
+
 	_, err := fsm.broadcastManager.GetStateChan(
 		ctx,
 		broadcast.WithCustomChannel(c),

--- a/fsm_test.go
+++ b/fsm_test.go
@@ -1005,3 +1005,24 @@ func TestGetStateChan_InitialSendIsAtomic(t *testing.T) {
 			i, got[0], got)
 	}
 }
+
+// TestGetStateChan_InitialSendRespectsContext verifies that the initial-state
+// send honors the context: with an unbuffered channel and no reader the send
+// blocks, and a cancelled context makes GetStateChan return the context error
+// instead of hanging while holding the FSM read lock.
+func TestGetStateChan_InitialSendRespectsContext(t *testing.T) {
+	t.Parallel()
+
+	reg, err := hooks.NewRegistry(hooks.WithTransitions(transitions.Typical))
+	require.NoError(t, err)
+	machine, err := New(transitions.StatusNew, transitions.Typical, WithCallbackRegistry(reg))
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel up front so the blocked initial send aborts
+
+	ch := make(chan string) // unbuffered, no reader: the initial send blocks
+	err = machine.GetStateChan(ctx, ch)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+}

--- a/fsm_test.go
+++ b/fsm_test.go
@@ -961,9 +961,7 @@ func TestGetStateChan_InitialSendIsAtomic(t *testing.T) {
 
 	stop := make(chan struct{})
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		for {
 			select {
 			case <-stop:
@@ -976,7 +974,7 @@ func TestGetStateChan_InitialSendIsAtomic(t *testing.T) {
 				runtime.Gosched()
 			}
 		}
-	}()
+	})
 	t.Cleanup(func() {
 		close(stop)
 		wg.Wait()
@@ -989,15 +987,15 @@ func TestGetStateChan_InitialSendIsAtomic(t *testing.T) {
 
 		// Collect the initial value plus the first broadcast.
 		var got []string
-		for len(got) < 2 {
+		require.Eventuallyf(t, func() bool {
 			select {
 			case s := <-ch:
 				got = append(got, s)
-			case <-time.After(2 * time.Second):
-				cancel()
-				t.Fatalf("iteration %d: timed out collecting states, got %v", i, got)
+			default:
 			}
-		}
+			return len(got) >= 2
+		}, 2*time.Second, time.Millisecond,
+			"iteration %d: timed out collecting states, got %v", i, got)
 		cancel()
 
 		require.NotEqualf(t, got[0], got[1],

--- a/fsm_test.go
+++ b/fsm_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"os"
+	"runtime"
 	"sync"
 	"testing"
 	"testing/synctest"
@@ -970,6 +971,9 @@ func TestGetStateChan_InitialSendIsAtomic(t *testing.T) {
 			default:
 				machine.TransitionBool(transitions.StatusReloading)
 				machine.TransitionBool(transitions.StatusRunning)
+				// Yield rather than spin flat-out; keeps transitions frequent
+				// enough to exercise the race without pegging a CPU under -race.
+				runtime.Gosched()
 			}
 		}
 	}()

--- a/fsm_test.go
+++ b/fsm_test.go
@@ -941,3 +941,63 @@ func TestGetStateChan_SharedRegistry(t *testing.T) {
 	assert.Equal(t, transitions.StatusNew, <-ch1)
 	assert.Equal(t, transitions.StatusNew, <-ch2)
 }
+
+// TestGetStateChan_InitialSendIsAtomic verifies that registering a subscriber
+// and sending its initial state happen atomically with respect to transitions.
+// Before GetStateChan held the read lock across registration and the initial
+// send, a concurrent transition could broadcast between the two steps, so the
+// subscriber observed a duplicated or stale first value. With strictly
+// alternating Running<->Reloading transitions, the initial value (current
+// state) and the first broadcast that follows must always differ; an equal
+// pair signals the race.
+func TestGetStateChan_InitialSendIsAtomic(t *testing.T) {
+	reg, err := hooks.NewRegistry(hooks.WithTransitions(transitions.Typical))
+	require.NoError(t, err)
+	machine, err := New(transitions.StatusRunning, transitions.Typical,
+		WithCallbackRegistry(reg),
+	)
+	require.NoError(t, err)
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				machine.TransitionBool(transitions.StatusReloading)
+				machine.TransitionBool(transitions.StatusRunning)
+			}
+		}
+	}()
+	t.Cleanup(func() {
+		close(stop)
+		wg.Wait()
+	})
+
+	for i := 0; i < 500; i++ {
+		ctx, cancel := context.WithCancel(context.Background())
+		ch := make(chan string, 256)
+		require.NoError(t, machine.GetStateChan(ctx, ch))
+
+		// Collect the initial value plus the first broadcast.
+		var got []string
+		for len(got) < 2 {
+			select {
+			case s := <-ch:
+				got = append(got, s)
+			case <-time.After(2 * time.Second):
+				cancel()
+				t.Fatalf("iteration %d: timed out collecting states, got %v", i, got)
+			}
+		}
+		cancel()
+
+		require.NotEqualf(t, got[0], got[1],
+			"iteration %d: initial value %q duplicated by the first broadcast %v; subscribe and initial send were not atomic",
+			i, got[0], got)
+	}
+}


### PR DESCRIPTION
## Problem

`Machine.GetStateChan` registered the subscriber with the broadcast manager and then sent the current state via `c <- fsm.GetState()` **without holding the FSM lock**. A transition broadcasting in that window made the subscriber's first values duplicated or out of order.

## Fix

Hold `fsm.mutex.RLock()` across both the channel registration and the initial send. Broadcasts only happen under the write lock (the post-transition hook runs inside `transition()`), so the read lock excludes them for the duration of registration + initial send; concurrent `GetStateChan` callers still proceed in parallel under the shared read lock.

Two consequences are now documented inline: the initial send occurs under the read lock, so a full/unbuffered channel blocks transitions until it drains (use a buffered channel — already the documented guidance), and `GetStateChan` must not be called from within a transition hook (which already holds the write lock).

## Tests

`TestGetStateChan_InitialSendIsAtomic`: with a goroutine strictly alternating `Running ↔ Reloading`, repeatedly subscribes and checks that the initial value and the first subsequent broadcast differ (they must, given alternating transitions). Verified it observes a duplicate first value at iteration 1 **without** the fix and passes with it, under `go test -race`.

Fixes #60

---
_Generated by [Claude Code](https://claude.ai/code/session_01MxceLKgW8yjqdvroh6GxJ5)_