### PR TITLE
fix(fsm): use per-machine hook name in GetStateChan

### DIFF
--- a/fsm.go
+++ b/fsm.go
@@ -326,6 +326,11 @@ func (fsm *Machine) transition(ctx context.Context, toState string) error {
 // GetStateChan can be called multiple times with different channels and contexts. All channels
 // share the same broadcast manager, which is lazily initialized only once upon the first call.
 //
+// Each Machine registers its broadcast hook under a name unique to that Machine, so a single
+// hooks.Registry may be shared across Machines without GetStateChan failing. Note, however, that
+// hooks registered on a shared registry fire for every Machine's transitions; prefer one registry
+// per Machine unless that shared behavior is intended.
+//
 // Broadcast delivery behavior is controlled by the timeout configured via WithBroadcastTimeout:
 //   - timeout = 0: best-effort delivery (non-blocking, drops if channel is full)
 //   - timeout > 0: blocks up to the timeout duration, then drops the message
@@ -385,8 +390,12 @@ func (fsm *Machine) GetStateChan(ctx context.Context, c chan string) error {
 	fsm.stateChanSetup.Do(func() {
 		fsm.broadcastManager = broadcast.NewManager(fsm.logger.Handler())
 
+		// Use a per-machine hook name so multiple machines can share one
+		// registry. A constant name would collide on the second machine
+		// (ErrHookNameAlreadyExists), and because the error is cached in the
+		// sync.Once that machine's GetStateChan would then fail permanently.
 		fsm.stateChanSetupErr = registrar.RegisterPostTransitionHook(hooks.PostTransitionHookConfig{
-			Name:   "fsm.GetStateChan",
+			Name:   fmt.Sprintf("fsm.GetStateChan.%p", fsm),
 			From:   []string{"*"},
 			To:     []string{"*"},
 			Action: fsm.broadcastManager.BroadcastHook,

--- a/fsm_test.go
+++ b/fsm_test.go
@@ -911,3 +911,33 @@ func TestFSM_GetStateChan(t *testing.T) {
 		})
 	})
 }
+
+// TestGetStateChan_SharedRegistry verifies that two machines can share a single
+// hooks.Registry. Previously GetStateChan registered its broadcast hook under a
+// constant name, so the second machine's registration failed with
+// ErrHookNameAlreadyExists and, because the error is cached in sync.Once, that
+// machine's GetStateChan failed permanently. With a per-machine hook name both
+// machines can subscribe.
+func TestGetStateChan_SharedRegistry(t *testing.T) {
+	t.Parallel()
+
+	reg, err := hooks.NewRegistry(hooks.WithTransitions(transitions.Typical))
+	require.NoError(t, err)
+
+	m1, err := New(transitions.StatusNew, transitions.Typical, WithCallbackRegistry(reg))
+	require.NoError(t, err)
+	m2, err := New(transitions.StatusNew, transitions.Typical, WithCallbackRegistry(reg))
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	ch1 := make(chan string, 10)
+	ch2 := make(chan string, 10)
+	require.NoError(t, m1.GetStateChan(ctx, ch1))
+	require.NoError(t, m2.GetStateChan(ctx, ch2)) // previously failed permanently
+
+	// Each subscriber receives its own machine's initial state.
+	assert.Equal(t, transitions.StatusNew, <-ch1)
+	assert.Equal(t, transitions.StatusNew, <-ch2)
+}


### PR DESCRIPTION
## Problem

`GetStateChan` registered its broadcast hook under the constant name `"fsm.GetStateChan"`. When two machines share one `hooks.Registry`, the second machine's registration fails with `ErrHookNameAlreadyExists`, and because the error is cached in `stateChanSetupErr` behind `sync.Once`, that machine's `GetStateChan` can never succeed.

## Fix

Register the hook under a per-machine name, `fmt.Sprintf("fsm.GetStateChan.%p", fsm)`, so each machine gets a distinct registration and a shared registry no longer collides.

I also documented a related caveat on `GetStateChan`: hooks registered on a shared registry fire for *every* machine's transitions (the registry can't tell which machine triggered a given transition), so one registry per machine is still preferred unless that shared behavior is intended. This PR removes the hard permanent-failure; the cross-machine hook execution is inherent to sharing a registry and is now called out in the docs rather than silently surprising.

## Tests

`TestGetStateChan_SharedRegistry`: two machines constructed with the same registry; both `GetStateChan` calls succeed and each subscriber receives its own machine's initial state. Verified it fails with `ErrHookNameAlreadyExists` under the old constant name and passes with the per-machine name.

Fixes #61

---
_Generated by [Claude Code](https://claude.ai/code/session_01MxceLKgW8yjqdvroh6GxJ5)_