### PR TITLE
fix(hooks): reject nil guard/action at registration

### DIFF
--- a/hooks/errors.go
+++ b/hooks/errors.go
@@ -17,4 +17,9 @@ var (
 
 	// ErrHookNotFound is returned when attempting to remove a hook that doesn't exist
 	ErrHookNotFound = errors.New("hook not found")
+
+	// ErrHookFuncNil is returned when registering a hook without its callback
+	// function (a nil Guard for a pre-transition hook or a nil Action for a
+	// post-transition hook).
+	ErrHookFuncNil = errors.New("hook function cannot be nil")
 )

--- a/hooks/registry.go
+++ b/hooks/registry.go
@@ -319,6 +319,20 @@ func (r *Registry) registerHookEntry(name string, entry *hookEntry) error {
 		return fmt.Errorf("from and to state lists cannot be empty")
 	}
 
+	// Reject a missing callback at registration time rather than letting it
+	// surface later as a recovered nil-pointer panic on the first matching
+	// transition.
+	switch entry.hookType {
+	case HookTypePre:
+		if entry.guard == nil {
+			return fmt.Errorf("%w: pre-transition hook %q requires a guard", ErrHookFuncNil, name)
+		}
+	case HookTypePost:
+		if entry.action == nil {
+			return fmt.Errorf("%w: post-transition hook %q requires an action", ErrHookFuncNil, name)
+		}
+	}
+
 	if _, exists := r.hooks[name]; exists {
 		return fmt.Errorf("%w: %s", ErrHookNameAlreadyExists, name)
 	}

--- a/hooks/registry_test.go
+++ b/hooks/registry_test.go
@@ -1168,3 +1168,50 @@ func TestRemoveHookConcurrentExecuteNoRace(t *testing.T) {
 		require.NoError(t, reg.RemoveHook(name))
 	}
 }
+
+// TestRegisterHook_NilFuncRejected verifies that registering a hook without its
+// callback fails fast at registration with ErrHookFuncNil, instead of being
+// accepted and later surfacing as a recovered nil-pointer panic
+// (ErrCallbackPanic) on the first matching transition.
+func TestRegisterHook_NilFuncRejected(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil guard rejected", func(t *testing.T) {
+		reg, err := NewRegistry()
+		require.NoError(t, err)
+		err = reg.RegisterPreTransitionHook(PreTransitionHookConfig{
+			Name:  "nil-guard",
+			From:  []string{"a"},
+			To:    []string{"b"},
+			Guard: nil,
+		})
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrHookFuncNil)
+	})
+
+	t.Run("nil action rejected", func(t *testing.T) {
+		reg, err := NewRegistry()
+		require.NoError(t, err)
+		err = reg.RegisterPostTransitionHook(PostTransitionHookConfig{
+			Name:   "nil-action",
+			From:   []string{"a"},
+			To:     []string{"b"},
+			Action: nil,
+		})
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrHookFuncNil)
+	})
+
+	t.Run("valid hooks still register", func(t *testing.T) {
+		reg, err := NewRegistry()
+		require.NoError(t, err)
+		require.NoError(t, reg.RegisterPreTransitionHook(PreTransitionHookConfig{
+			Name: "ok-guard", From: []string{"a"}, To: []string{"b"},
+			Guard: func(ctx context.Context, from, to string) error { return nil },
+		}))
+		require.NoError(t, reg.RegisterPostTransitionHook(PostTransitionHookConfig{
+			Name: "ok-action", From: []string{"a"}, To: []string{"b"},
+			Action: func(ctx context.Context, from, to string) {},
+		}))
+	})
+}


### PR DESCRIPTION
## Problem

`RegisterPreTransitionHook`/`RegisterPostTransitionHook` didn't validate that the callback was non-nil. A nil `Guard` (pre) or `Action` (post) registered successfully, then every matching transition failed with a recovered nil-pointer panic wrapped as `ErrCallbackPanic` — the error surfaced at transition time, far from the actual mistake.

## Fix

Validate the callback in `registerHookEntry` (Phase 1, fail-fast): pre-transition hooks require a non-nil `guard`, post-transition hooks a non-nil `action`. Returns the new `ErrHookFuncNil` sentinel with context naming the offending hook.

## Tests

`TestRegisterHook_NilFuncRejected`: asserts a nil guard and a nil action are each rejected at registration with `ErrHookFuncNil`, and that valid hooks still register. Verified the nil cases register without error before the fix and are rejected after it.

Fixes #62

---
_Generated by [Claude Code](https://claude.ai/code/session_01MxceLKgW8yjqdvroh6GxJ5)_