### PR TITLE
fix(broadcast): close manager-owned fallback channel for nil custom channel

### DIFF
--- a/hooks/broadcast/manager.go
+++ b/hooks/broadcast/manager.go
@@ -65,7 +65,11 @@ func (m *Manager) GetStateChan(ctx context.Context, opts ...Option) (<-chan stri
 	if config.channel != nil {
 		ch = config.channel
 	} else {
+		// Fall back to a manager-owned channel. Reset externalChannel in case a
+		// caller passed WithCustomChannel(nil), which would otherwise leave it
+		// true and prevent the cleanup goroutine from closing this channel.
 		ch = make(chan string, 1)
+		config.externalChannel = false
 	}
 
 	// Register subscriber

--- a/hooks/broadcast/manager_test.go
+++ b/hooks/broadcast/manager_test.go
@@ -569,3 +569,29 @@ func TestBroadcast_CancelledGuaranteedSubscriberDoesNotDeadlock(t *testing.T) {
 		t.Fatal("manager wedged: a fresh subscriber received no broadcast after the deadlock scenario")
 	}
 }
+
+// TestGetStateChan_NilCustomChannelIsManagerOwned verifies that passing
+// WithCustomChannel(nil) yields a manager-owned channel that is closed on
+// context cancellation. Previously externalChannel stayed true for a nil custom
+// channel, so the fallback internal channel was never closed and readers
+// ranging over it blocked forever.
+func TestGetStateChan_NilCustomChannelIsManagerOwned(t *testing.T) {
+	t.Parallel()
+
+	manager := broadcast.NewManager(newTestLogger().Handler())
+	ctx, cancel := context.WithCancel(context.Background())
+
+	ch, err := manager.GetStateChan(ctx, broadcast.WithCustomChannel(nil))
+	require.NoError(t, err)
+	require.NotNil(t, ch)
+
+	cancel()
+
+	// The manager owns this channel, so it must be closed after cancellation.
+	select {
+	case _, ok := <-ch:
+		assert.False(t, ok, "manager-owned channel should be closed after context cancellation")
+	case <-time.After(2 * time.Second):
+		t.Fatal("channel was not closed after cancellation; nil custom channel was wrongly treated as external")
+	}
+}

--- a/hooks/broadcast/manager_test.go
+++ b/hooks/broadcast/manager_test.go
@@ -579,7 +579,9 @@ func TestGetStateChan_NilCustomChannelIsManagerOwned(t *testing.T) {
 	t.Parallel()
 
 	manager := broadcast.NewManager(newTestLogger().Handler())
-	ctx, cancel := context.WithCancel(context.Background())
+	// Derive from t.Context() so the subscription is cancelled on test
+	// completion even if an assertion below fails before the explicit cancel().
+	ctx, cancel := context.WithCancel(t.Context())
 
 	ch, err := manager.GetStateChan(ctx, broadcast.WithCustomChannel(nil))
 	require.NoError(t, err)
@@ -591,7 +593,7 @@ func TestGetStateChan_NilCustomChannelIsManagerOwned(t *testing.T) {
 	select {
 	case _, ok := <-ch:
 		assert.False(t, ok, "manager-owned channel should be closed after context cancellation")
-	case <-time.After(2 * time.Second):
+	case <-time.After(time.Second):
 		t.Fatal("channel was not closed after cancellation; nil custom channel was wrongly treated as external")
 	}
 }


### PR DESCRIPTION
## Problem

`WithCustomChannel(nil)` sets `config.externalChannel = true` with a nil channel. `GetStateChan` then falls back to creating an internal channel (`make(chan string, 1)`) but leaves `externalChannel` true, so the context-cancel cleanup goroutine never closes that manager-owned channel. Readers ranging over it block forever.

## Fix

When falling back to an internal channel, reset `config.externalChannel = false` so the cleanup goroutine closes the manager-owned channel on cancellation.

## Tests

`TestGetStateChan_NilCustomChannelIsManagerOwned`: calls `GetStateChan` with `WithCustomChannel(nil)`, cancels the context, and asserts the returned channel is closed. Verified it hangs/times out without the fix and passes with it.

Fixes #63

---
_Generated by [Claude Code](https://claude.ai/code/session_01MxceLKgW8yjqdvroh6GxJ5)_