### PR TITLE
chore: require Go 1.26.4

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,7 @@ version: '2'
 
 run:
   timeout: 5m
-  go: '1.25'
+  go: '1.26'
 
 linters:
   default: standard

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/robbyt/go-fsm/v2
 
-go 1.25.6
+go 1.26.4
 
 require github.com/stretchr/testify v1.11.1
 


### PR DESCRIPTION
## Summary

Bump the minimum Go version from **1.25.6** to **1.26.4** (current stable).

- `go.mod`: `go 1.26.4`
- `.golangci.yml`: `run.go: '1.26'` (this setting uses major.minor)

## Notes

- Both CI workflows (`go.yml`, `sonarqube.yml`) use `actions/setup-go` with `go-version-file: go.mod`, so they pick up 1.26.4 automatically — no workflow edits needed.
- No other hardcoded version references in the repo (README, docs).

## Test plan

- [x] `go build ./...` on the go1.26.4 toolchain
- [x] `go test -race ./...` — all packages pass on 1.26.4

> Local `golangci-lint` couldn't be run in my environment because the locally installed binary (v2.5.0, built with go1.25) refuses to target go 1.26. CI runs `golangci-lint-action@v9` with `version: latest`, which is built against go 1.26+, so the lint job will run normally there.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MxceLKgW8yjqdvroh6GxJ5)_