### PR TITLE
feat(fsm): add IsTransitionAllowed, AvailableTransitions, IsTerminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A finite state machine that supports custom states and allowed transitions with 
 ## Features
 
 - Define custom states and allowed transitions
+- Inspect allowed transitions from the current state (`CanTransitionTo`, `AvailableTransitions`, `IsTerminal`)
 - Thread-safe state management using atomic operations
 - Functional hook callbacks (pre-transition hooks, post-transition hooks)
 - Subscribe to state changes via channels with context support
@@ -504,6 +505,28 @@ err = machine.SetState("offline")
 
 // GetState: Returns the current state.
 currentState := machine.GetState()
+```
+
+### Inspecting Allowed Transitions
+
+These read-only helpers report what the FSM can do from its current state,
+without mutating it. They are useful for gating UI/decisions or detecting
+completion. Each is a lock-free, point-in-time snapshot (like `GetState`).
+
+```go
+// CanTransitionTo: is a transition to the given state allowed right now?
+if machine.CanTransitionTo("offline") {
+	_ = machine.Transition("offline")
+}
+
+// AvailableTransitions: the states reachable from the current state,
+// sorted alphabetically (empty when the current state is terminal).
+next := machine.AvailableTransitions() // e.g. []string{"offline"}
+
+// IsTerminal: true when the current state has no outgoing transitions.
+if machine.IsTerminal() {
+	// the machine has reached an end state
+}
 ```
 
 ## Complete Example

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A finite state machine that supports custom states and allowed transitions with 
 ## Features
 
 - Define custom states and allowed transitions
-- Inspect allowed transitions from the current state (`CanTransitionTo`, `AvailableTransitions`, `IsTerminal`)
+- Inspect allowed transitions from the current state (`IsTransitionAllowed`, `AvailableTransitions`, `IsTerminal`)
 - Thread-safe state management using atomic operations
 - Functional hook callbacks (pre-transition hooks, post-transition hooks)
 - Subscribe to state changes via channels with context support
@@ -514,8 +514,8 @@ without mutating it. They are useful for gating UI/decisions or detecting
 completion. Each is a lock-free, point-in-time snapshot (like `GetState`).
 
 ```go
-// CanTransitionTo: is a transition to the given state allowed right now?
-if machine.CanTransitionTo("offline") {
+// IsTransitionAllowed: is a transition to the given state allowed right now?
+if machine.IsTransitionAllowed("offline") {
 	_ = machine.Transition("offline")
 }
 

--- a/fsm.go
+++ b/fsm.go
@@ -39,6 +39,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -174,17 +175,19 @@ func (fsm *Machine) GetAllStates() []string {
 	return fsm.transitions.GetAllStates()
 }
 
-// CanTransitionTo reports whether a transition from the current state to
-// toState is currently allowed by the transition table. It is a point-in-time
-// snapshot: like GetState, it takes no mutex, so the result may be stale if a
-// concurrent transition is in flight.
-func (fsm *Machine) CanTransitionTo(toState string) bool {
+// IsTransitionAllowed reports whether a transition from the current state to
+// toState is permitted by the transition table. It mirrors
+// transitions.Config.IsTransitionAllowed with the current state as the source.
+// Like GetState, it takes no mutex and is a point-in-time snapshot, so the
+// result may be stale if a concurrent transition is in flight.
+func (fsm *Machine) IsTransitionAllowed(toState string) bool {
 	return fsm.transitions.IsTransitionAllowed(fsm.GetState(), toState)
 }
 
 // AvailableTransitions returns the states the FSM may transition to from its
 // current state, sorted alphabetically. It returns an empty slice when the
-// current state is terminal (or unknown). Like GetState, this is a lock-free
+// current state has no outgoing transitions — that is, when it is terminal or
+// not present in the transition table. Like GetState, this is a lock-free
 // point-in-time snapshot.
 func (fsm *Machine) AvailableTransitions() []string {
 	current := fsm.GetState()
@@ -195,13 +198,22 @@ func (fsm *Machine) AvailableTransitions() []string {
 			available = append(available, state)
 		}
 	}
+	// Sort explicitly: the transitionDB contract does not guarantee
+	// GetAllStates ordering, but this method documents sorted output.
+	slices.Sort(available)
 	return available
 }
 
 // IsTerminal reports whether the current state has no outgoing transitions.
 // Like GetState, this is a lock-free point-in-time snapshot.
 func (fsm *Machine) IsTerminal() bool {
-	return len(fsm.AvailableTransitions()) == 0
+	current := fsm.GetState()
+	for _, state := range fsm.transitions.GetAllStates() {
+		if fsm.transitions.IsTransitionAllowed(current, state) {
+			return false
+		}
+	}
+	return true
 }
 
 // SetState updates the FSM's state, bypassing transition rules and pre-transition hooks.

--- a/fsm.go
+++ b/fsm.go
@@ -174,6 +174,36 @@ func (fsm *Machine) GetAllStates() []string {
 	return fsm.transitions.GetAllStates()
 }
 
+// CanTransitionTo reports whether a transition from the current state to
+// toState is currently allowed by the transition table. It is a point-in-time
+// snapshot: like GetState, it takes no mutex, so the result may be stale if a
+// concurrent transition is in flight.
+func (fsm *Machine) CanTransitionTo(toState string) bool {
+	return fsm.transitions.IsTransitionAllowed(fsm.GetState(), toState)
+}
+
+// AvailableTransitions returns the states the FSM may transition to from its
+// current state, sorted alphabetically. It returns an empty slice when the
+// current state is terminal (or unknown). Like GetState, this is a lock-free
+// point-in-time snapshot.
+func (fsm *Machine) AvailableTransitions() []string {
+	current := fsm.GetState()
+	allStates := fsm.transitions.GetAllStates()
+	available := make([]string, 0, len(allStates))
+	for _, state := range allStates {
+		if fsm.transitions.IsTransitionAllowed(current, state) {
+			available = append(available, state)
+		}
+	}
+	return available
+}
+
+// IsTerminal reports whether the current state has no outgoing transitions.
+// Like GetState, this is a lock-free point-in-time snapshot.
+func (fsm *Machine) IsTerminal() bool {
+	return len(fsm.AvailableTransitions()) == 0
+}
+
 // SetState updates the FSM's state, bypassing transition rules and pre-transition hooks.
 // Returns an error if the state is not defined in the transition table.
 func (fsm *Machine) SetState(state string) error {

--- a/fsm_test.go
+++ b/fsm_test.go
@@ -1025,16 +1025,16 @@ func TestGetStateChan_InitialSendRespectsContext(t *testing.T) {
 	assert.ErrorIs(t, err, context.Canceled)
 }
 
-func TestFSM_CanTransitionTo(t *testing.T) {
+func TestFSM_IsTransitionAllowed(t *testing.T) {
 	t.Parallel()
 
 	machine, err := New(transitions.StatusRunning, transitions.Typical)
 	require.NoError(t, err)
 
-	assert.True(t, machine.CanTransitionTo(transitions.StatusReloading), "Running->Reloading is allowed")
-	assert.True(t, machine.CanTransitionTo(transitions.StatusError), "Running->Error is allowed")
-	assert.False(t, machine.CanTransitionTo(transitions.StatusNew), "Running->New is not allowed")
-	assert.False(t, machine.CanTransitionTo("nonexistent"), "unknown target is not allowed")
+	assert.True(t, machine.IsTransitionAllowed(transitions.StatusReloading), "Running->Reloading is allowed")
+	assert.True(t, machine.IsTransitionAllowed(transitions.StatusError), "Running->Error is allowed")
+	assert.False(t, machine.IsTransitionAllowed(transitions.StatusNew), "Running->New is not allowed")
+	assert.False(t, machine.IsTransitionAllowed("nonexistent"), "unknown target is not allowed")
 }
 
 func TestFSM_AvailableTransitions(t *testing.T) {

--- a/fsm_test.go
+++ b/fsm_test.go
@@ -1024,3 +1024,70 @@ func TestGetStateChan_InitialSendRespectsContext(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorIs(t, err, context.Canceled)
 }
+
+func TestFSM_CanTransitionTo(t *testing.T) {
+	t.Parallel()
+
+	machine, err := New(transitions.StatusRunning, transitions.Typical)
+	require.NoError(t, err)
+
+	assert.True(t, machine.CanTransitionTo(transitions.StatusReloading), "Running->Reloading is allowed")
+	assert.True(t, machine.CanTransitionTo(transitions.StatusError), "Running->Error is allowed")
+	assert.False(t, machine.CanTransitionTo(transitions.StatusNew), "Running->New is not allowed")
+	assert.False(t, machine.CanTransitionTo("nonexistent"), "unknown target is not allowed")
+}
+
+func TestFSM_AvailableTransitions(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns sorted allowed targets from current state", func(t *testing.T) {
+		machine, err := New(transitions.StatusRunning, transitions.Typical)
+		require.NoError(t, err)
+
+		assert.Equal(t,
+			[]string{transitions.StatusError, transitions.StatusReloading, transitions.StatusStopping},
+			machine.AvailableTransitions(),
+		)
+	})
+
+	t.Run("includes a self-loop target", func(t *testing.T) {
+		machine, err := New(transitions.StatusUnknown, transitions.Typical)
+		require.NoError(t, err)
+
+		assert.Equal(t, []string{transitions.StatusUnknown}, machine.AvailableTransitions())
+	})
+
+	t.Run("returns empty slice for a terminal state", func(t *testing.T) {
+		machine, err := NewSimple("a", map[string][]string{
+			"a": {"b"},
+			"b": {},
+		})
+		require.NoError(t, err)
+		require.NoError(t, machine.Transition("b"))
+
+		assert.Empty(t, machine.AvailableTransitions())
+	})
+}
+
+func TestFSM_IsTerminal(t *testing.T) {
+	t.Parallel()
+
+	t.Run("true when current state has no outgoing transitions", func(t *testing.T) {
+		machine, err := NewSimple("a", map[string][]string{
+			"a": {"b"},
+			"b": {},
+		})
+		require.NoError(t, err)
+
+		assert.False(t, machine.IsTerminal(), "a has an outgoing transition")
+		require.NoError(t, machine.Transition("b"))
+		assert.True(t, machine.IsTerminal(), "b is terminal")
+	})
+
+	t.Run("false for a self-looping state", func(t *testing.T) {
+		machine, err := New(transitions.StatusUnknown, transitions.Typical)
+		require.NoError(t, err)
+
+		assert.False(t, machine.IsTerminal(), "Unknown self-loops, so it is not terminal")
+	})
+}


### PR DESCRIPTION
## Summary

Adds current-state introspection to `Machine`, so callers can query what the FSM can do from its current state without reaching into the transition table. Surfaced while reviewing peer Go FSM libraries (looplab/fsm's most-used helpers are `Can()` / `AvailableTransitions()`).

New methods:
- **`IsTransitionAllowed(toState string) bool`** — is `current → toState` allowed right now? Mirrors `transitions.Config.IsTransitionAllowed`, with the current state as the implicit source.
- **`AvailableTransitions() []string`** — allowed next states from the current state, sorted alphabetically; empty when terminal.
- **`IsTerminal() bool`** — does the current state have no outgoing transitions?

## Design

- Built entirely on the existing (unexported) `transitionDB` interface — `IsTransitionAllowed` + `GetAllStates`. **No interface change**, so any custom `transitionDB` implementation keeps satisfying it.
- Lock-free point-in-time snapshots, consistent with the existing `GetState()` (atomic load) and `GetAllStates()` (table is immutable post-construction). For an *atomic* check-then-act, use `TransitionIfCurrentState` (compare-and-swap).
- `AvailableTransitions` sorts its result explicitly via `slices.Sort` — the `transitionDB` contract doesn't guarantee `GetAllStates` ordering, so this keeps the sorted-output contract regardless of implementation.
- `IsTerminal` scans for the first allowed transition and returns early (no slice allocation).

## Tests

`fsm_test.go`: `IsTransitionAllowed` (allowed / disallowed / unknown), `AvailableTransitions` (sorted set from `Typical` at `Running`; self-loop at `Unknown`; empty at a terminal state), and `IsTerminal` (terminal vs. non-terminal vs. self-loop). All pass under `go test -race`; `go vet` clean.

## Notes

- New exported API → next release is a **minor** bump (v2.5.0).
- Docs updated (README Features list + a new "Inspecting Allowed Transitions" section).

---
_Generated by [Claude Code](https://claude.ai/code/session_01MxceLKgW8yjqdvroh6GxJ5)_