### PR TITLE
[superseded] fix: resolve the High and Medium issues from the 2026-07-30 code review

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,8 +421,28 @@ _ = machine.Transition(transitions.StatusBooting)
 The `GetStateChan()` method:
 - Automatically sets up broadcast management
 - Sends the current state immediately upon subscription
-- Unsubscribes the channel when the context is cancelled
+- Ends the subscription when the context is cancelled
 - Supports multiple concurrent subscribers
+- Accepts each channel only once per machine; a second subscription returns `broadcast.ErrChannelAlreadySubscribed`
+
+#### Ending a Subscription
+
+Cancelling the context ends the subscription. The channel is yours: the FSM never
+closes it, and you should not close it while it is still subscribed.
+
+When a `hooks.Registry` outlives the machines using it, call `Close` on a machine
+you are discarding. `GetStateChan` registers a per-machine broadcast hook on the
+registry; without `Close` that hook — and its broadcast manager — keeps firing on
+every other machine's transitions for the life of the registry:
+
+```go
+machine, _ := fsm.New(transitions.StatusNew, transitions.Typical,
+	fsm.WithCallbackRegistry(sharedRegistry))
+defer machine.Close() // releases subscribers and removes the broadcast hook
+```
+
+`Close` releases only the subscription plumbing. The machine's state operations
+and any hooks you registered yourself keep working.
 
 Configure broadcast timeout behavior with `fsm.WithBroadcastTimeout()`:
 

--- a/callbacks.go
+++ b/callbacks.go
@@ -45,3 +45,15 @@ type HookRegistrar interface {
 	RegisterPostTransitionHook(config hooks.PostTransitionHookConfig) error
 	RegisterPreTransitionHook(config hooks.PreTransitionHookConfig) error
 }
+
+// HookRemover is the optional interface a CallbackExecutor may implement to
+// support removing a previously registered hook by name. Machine.Close uses it
+// to remove the broadcast hook installed by GetStateChan; a CallbackExecutor
+// that does not implement it makes Close return an error naming the hook that
+// must be removed by hand. The hooks.Registry type implements this interface.
+//
+// It is deliberately separate from HookRegistrar: adding a method to that
+// interface would break every third-party implementation of it.
+type HookRemover interface {
+	RemoveHook(name string) error
+}

--- a/docs/v2-upgrade.md
+++ b/docs/v2-upgrade.md
@@ -167,6 +167,15 @@ machine, err := fsm.New(
 
 ### Step 7: Migrate GetStateChan Usage (Critical)
 
+> **New in v2.5:** `machine.Close()` releases every subscriber and removes the
+> machine's broadcast hook from the registry — call it when discarding a machine
+> whose `hooks.Registry` outlives it. Three other behaviours tightened in the
+> same release: subscribing the same channel twice on one machine now returns
+> `broadcast.ErrChannelAlreadySubscribed`, subscribing with an already-cancelled
+> context now fails deterministically instead of racing, and passing a nil
+> channel returns `fsm.ErrNilStateChannel` rather than deadlocking the machine.
+
+
 This changed significantly in v2. The v2 API provides a built-in helper method on the FSM.
 
 #### Decision Guide: Which Broadcasting Pattern Should You Use?
@@ -571,6 +580,7 @@ Use this checklist to verify your migration:
 - [ ] Updated `fsm.New()` constructor calls (moved handler to options)
 - [ ] Migrated `GetStateChan()` to use `machine.GetStateChan(ctx, chan)` with hooks.Registry
 - [ ] Added `WithBroadcastTimeout()` option if custom timeout needed (replaces `WithSyncTimeout`)
+- [ ] Called `machine.Close()` for machines sharing a long-lived `hooks.Registry` (v2.5+)
 - [ ] **Created single abstraction constructor (if architecture supports it)**
 - [ ] Updated all tests
 - [ ] Verified with `go build ./...`

--- a/errors.go
+++ b/errors.go
@@ -35,3 +35,15 @@ var ErrEmptyTransitions = errors.New("transitions cannot be empty")
 
 // ErrInvalidJSONTransitions is returned when JSON transitions configuration is invalid
 var ErrInvalidJSONTransitions = errors.New("invalid transitions in JSON")
+
+// ErrNilStateChannel is returned when GetStateChan is called with a nil channel
+var ErrNilStateChannel = errors.New("state channel cannot be nil")
+
+// ErrNoCallbackRegistry is returned when GetStateChan is called on a Machine
+// that has no callback registry, or one that does not support dynamic hook
+// registration
+var ErrNoCallbackRegistry = errors.New("GetStateChan requires a callback registry")
+
+// ErrMachineClosed is returned when GetStateChan is called on a Machine whose
+// broadcast plumbing has been released by Close
+var ErrMachineClosed = errors.New("machine is closed")

--- a/fsm.go
+++ b/fsm.go
@@ -37,6 +37,7 @@ package fsm
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"slices"
@@ -56,7 +57,10 @@ import (
 // (GetAllStates, HasState, IsTransitionAllowed all run lock-free), so any
 // locking or copying needed for read safety is the implementation's
 // responsibility. The bundled transitions.Config satisfies this contract:
-// its index is built once at construction and never mutated.
+// its index is built once at construction and never mutated. The one exception
+// is transitions.Config.UnmarshalJSON, which rebuilds the config in place; see
+// its doc comment. Never unmarshal into a Config that is already attached to a
+// Machine.
 type transitionDB interface {
 	HasState(state string) bool
 	GetAllStates() []string
@@ -73,11 +77,32 @@ type Machine struct {
 	callbacks   CallbackExecutor
 	logger      *slog.Logger
 
-	broadcastManager  *broadcast.Manager
-	broadcastTimeout  time.Duration
-	stateChanSetup    sync.Once
-	stateChanSetupErr error
+	broadcastTimeout time.Duration
+
+	// id is a process-unique identifier assigned by New, used to build a
+	// collision-free name for this Machine's broadcast hook. A Machine built
+	// without New (the zero value) gets id 0, but such a Machine already fails
+	// on any transition, so it is not guarded here.
+	id uint64
+
+	// subMu gates the lazily-created broadcast plumbing below. It is separate
+	// from mutex on purpose: a broadcast runs from a post-transition hook while
+	// mutex is held for writing, so Close must never take mutex -- it has to be
+	// able to reach the broadcast manager to release exactly that broadcast.
+	//
+	// Nested lock order: mutex -> subMu. Never acquire mutex while holding subMu.
+	subMu            sync.RWMutex
+	broadcastManager *broadcast.Manager
+	hookName         string
+	closed           bool
+	closeErr         error
 }
+
+// machineIDCounter stamps each Machine with a process-unique id. A pointer
+// (%p) is not unique over time: a garbage-collected Machine's address can be
+// reused by a later allocation, and on a shared registry that produced a
+// spurious ErrHookNameAlreadyExists for the new Machine.
+var machineIDCounter atomic.Uint64
 
 // New creates a finite state machine with the specified initial state and transitions.
 // For simpler usage with inline maps, see NewSimple().
@@ -119,6 +144,7 @@ func New(
 		transitions:      trans,
 		logger:           slog.New(handler),
 		broadcastTimeout: 100 * time.Millisecond,
+		id:               machineIDCounter.Add(1),
 	}
 	m.state.Store(initialState)
 
@@ -368,17 +394,27 @@ func (fsm *Machine) transition(ctx context.Context, toState string) error {
 // The registry must be created with WithTransitions() to support wildcard pattern matching.
 // Returns an error if the callback executor does not support dynamic hook registration.
 //
-// The channel will automatically receive all future state transitions until the context
-// is cancelled, at which point it is automatically unsubscribed from receiving further broadcasts.
-// The channel is NOT closed; the caller maintains ownership and is responsible for channel lifecycle.
+// The channel receives all future state transitions until the context is cancelled, or
+// the Machine is closed with Close — whichever comes first. The channel is NOT closed;
+// the caller maintains ownership and is responsible for its lifecycle, and must not
+// close it while it is still subscribed.
+//
+// Passing a non-cancellable context (context.Background()) is supported, but then Close
+// is the only way to end the subscription: a subscriber that is simply dropped stays
+// registered for the life of the Machine. Prefer a cancellable context.
 //
 // GetStateChan can be called multiple times with different channels and contexts. All channels
 // share the same broadcast manager, which is lazily initialized only once upon the first call.
+// A channel may hold only one live subscription per Machine; subscribing the same channel twice
+// returns broadcast.ErrChannelAlreadySubscribed. Re-subscribing a channel whose previous
+// subscription has ended is allowed, as is subscribing one channel to several Machines.
+// An already-cancelled context is rejected.
 //
 // Each Machine registers its broadcast hook under a name unique to that Machine, so a single
 // hooks.Registry may be shared across Machines without GetStateChan failing. Note, however, that
-// hooks registered on a shared registry fire for every Machine's transitions; prefer one registry
-// per Machine unless that shared behavior is intended.
+// hooks registered on a shared registry fire for every Machine's transitions. When sharing a
+// registry, call Close on a Machine you are discarding, or its broadcast hook keeps firing on
+// every other Machine's transitions for the life of the registry.
 //
 // Broadcast delivery behavior is controlled by the timeout configured via WithBroadcastTimeout:
 //   - timeout = 0: best-effort delivery (non-blocking, drops if channel is full)
@@ -389,7 +425,8 @@ func (fsm *Machine) transition(ctx context.Context, toState string) error {
 //
 // The channel must be bidirectional (chan string, not <-chan string) to allow the FSM
 // to send state updates. The caller maintains ownership of the channel and controls
-// its buffer size and lifecycle.
+// its buffer size and lifecycle. It must be non-nil; a nil channel returns
+// ErrNilStateChannel without registering a subscriber.
 //
 // Example:
 //
@@ -424,35 +461,29 @@ func (fsm *Machine) transition(ctx context.Context, toState string) error {
 //	}()
 func (fsm *Machine) GetStateChan(ctx context.Context, c chan string) error {
 	if ctx == nil {
-		return fmt.Errorf("context cannot be nil")
+		return fmt.Errorf("%w: context cannot be nil", ErrInvalidConfiguration)
+	}
+
+	// Reject a nil channel before anything is registered. A nil channel makes the
+	// initial-state send below block forever, and because that send happens under
+	// the FSM read lock it would wedge every subsequent Transition, SetState, and
+	// MarshalJSON on this machine, with no way to recover when the context is not
+	// cancellable.
+	if c == nil {
+		return ErrNilStateChannel
 	}
 
 	if fsm.callbacks == nil {
-		return fmt.Errorf("GetStateChan requires a callback registry")
+		return ErrNoCallbackRegistry
 	}
 
 	registrar, ok := fsm.callbacks.(HookRegistrar)
 	if !ok {
-		return fmt.Errorf("GetStateChan requires a callback registry that supports dynamic hook registration")
+		return fmt.Errorf("%w that supports dynamic hook registration", ErrNoCallbackRegistry)
 	}
 
-	fsm.stateChanSetup.Do(func() {
-		fsm.broadcastManager = broadcast.NewManager(fsm.logger.Handler())
-
-		// Use a per-machine hook name so multiple machines can share one
-		// registry. A constant name would collide on the second machine
-		// (ErrHookNameAlreadyExists), and because the error is cached in the
-		// sync.Once that machine's GetStateChan would then fail permanently.
-		fsm.stateChanSetupErr = registrar.RegisterPostTransitionHook(hooks.PostTransitionHookConfig{
-			Name:   fmt.Sprintf("fsm.GetStateChan.%p", fsm),
-			From:   []string{"*"},
-			To:     []string{"*"},
-			Action: fsm.broadcastManager.BroadcastHook,
-		})
-	})
-
-	if fsm.stateChanSetupErr != nil {
-		return fsm.stateChanSetupErr
+	if _, err := fsm.ensureBroadcast(registrar); err != nil {
+		return err
 	}
 
 	// Register the subscriber and send the current state while holding the read
@@ -466,6 +497,18 @@ func (fsm *Machine) GetStateChan(ctx context.Context, c chan string) error {
 	fsm.mutex.RLock()
 	defer fsm.mutex.RUnlock()
 
+	// subMu is held for reading across registration and the initial send so a
+	// concurrent Close cannot detach the manager underneath us and leave this
+	// subscriber permanently silent. Close takes it for writing, so it waits for
+	// subscriptions already in flight and blocks new ones. Both are read locks
+	// here, so concurrent GetStateChan callers still proceed in parallel.
+	fsm.subMu.RLock()
+	defer fsm.subMu.RUnlock()
+
+	if fsm.closed {
+		return ErrMachineClosed
+	}
+
 	_, err := fsm.broadcastManager.GetStateChan(
 		ctx,
 		broadcast.WithCustomChannel(c),
@@ -478,11 +521,118 @@ func (fsm *Machine) GetStateChan(ctx context.Context, c chan string) error {
 	// Honor the context during the initial send so a full/unbuffered channel
 	// cannot block here (and thus block transitions, since we hold the read
 	// lock) past the caller's cancellation. The subscriber is unsubscribed by
-	// the same ctx cancellation via the broadcast manager's cleanup goroutine.
+	// the same ctx cancellation, via the broadcast manager.
 	select {
 	case c <- fsm.GetState():
 	case <-ctx.Done():
 		return fmt.Errorf("state channel registration canceled: %w", ctx.Err())
+	}
+
+	return nil
+}
+
+// ensureBroadcast lazily creates this Machine's broadcast manager and registers
+// its post-transition broadcast hook, returning the manager.
+//
+// It replaces a sync.Once, which Close made untenable: a Once cannot be undone,
+// reading the manager it writes from a goroutine that never called Do would be a
+// data race, and a cached setup error permanently poisoned the Machine. A failed
+// setup is no longer cached -- the next call retries.
+//
+// subMu is released before returning, so this never holds it while acquiring
+// fsm.mutex and therefore does not participate in the mutex -> subMu order.
+func (fsm *Machine) ensureBroadcast(registrar HookRegistrar) (*broadcast.Manager, error) {
+	fsm.subMu.Lock()
+	defer fsm.subMu.Unlock()
+
+	if fsm.closed {
+		return nil, ErrMachineClosed
+	}
+
+	if fsm.broadcastManager != nil {
+		return fsm.broadcastManager, nil
+	}
+
+	manager := broadcast.NewManager(fsm.logger.Handler())
+
+	// Name the hook after this Machine's process-unique id so several Machines
+	// can share one registry without colliding.
+	name := fmt.Sprintf("fsm.GetStateChan.%d", fsm.id)
+	if err := registrar.RegisterPostTransitionHook(hooks.PostTransitionHookConfig{
+		Name:   name,
+		From:   []string{"*"},
+		To:     []string{"*"},
+		Action: manager.BroadcastHook,
+	}); err != nil {
+		return nil, err
+	}
+
+	fsm.broadcastManager = manager
+	fsm.hookName = name
+
+	return manager, nil
+}
+
+// Close releases only the state-subscription resources this Machine created:
+// it ends every live GetStateChan subscription and removes the broadcast hook
+// that GetStateChan registered on the callback registry. It does NOT stop the
+// Machine -- GetState, Transition, SetState, MarshalJSON, and every hook the
+// caller registered themselves keep working exactly as before.
+//
+// Call it when discarding a Machine whose hooks.Registry outlives it (a shared
+// registry). Otherwise that hook, and the broadcast manager behind it, keep
+// firing on every transition of every other Machine using that registry.
+//
+// Channels supplied to GetStateChan are owned by the caller and are not closed;
+// their subscribers see silence, exactly as when their context is cancelled.
+// After Close, GetStateChan returns ErrMachineClosed.
+//
+// Close is idempotent, but it does not forget a failure: if removing the hook
+// fails, every subsequent call returns that same error, because a silently
+// orphaned hook is the exact condition Close exists to prevent.
+//
+// Close blocks while an in-flight broadcast completes, and can block for as long
+// as a concurrent GetStateChan holds the subscription gate -- which, with an
+// unbuffered channel and a non-cancellable context, may be indefinitely. It is
+// safe to call from a transition hook: Close never takes the FSM mutex, and hook
+// executors release the registry lock before running hooks.
+func (fsm *Machine) Close() error {
+	fsm.subMu.Lock()
+	defer fsm.subMu.Unlock()
+
+	if fsm.closed {
+		return fsm.closeErr
+	}
+	fsm.closed = true
+
+	manager, hookName := fsm.broadcastManager, fsm.hookName
+	if manager == nil {
+		// GetStateChan was never called: nothing was ever registered.
+		return nil
+	}
+
+	// Release subscribers first. UnsubscribeAll signals every subscription
+	// before taking the manager mutex, so it cannot be blocked by the very
+	// broadcast it is trying to free.
+	manager.UnsubscribeAll()
+	fsm.broadcastManager = nil
+	fsm.hookName = ""
+
+	remover, ok := fsm.callbacks.(HookRemover)
+	if !ok {
+		// Still closed and still unsubscribed: a partial failure must not leave
+		// the Machine half-open. Name the hook so it can be removed by hand.
+		fsm.closeErr = fmt.Errorf(
+			"%w: callback registry does not support removing hooks; hook %q is orphaned",
+			ErrInvalidConfiguration, hookName,
+		)
+		return fsm.closeErr
+	}
+
+	// A hook the caller already removed is not an error.
+	if err := remover.RemoveHook(hookName); err != nil && !errors.Is(err, hooks.ErrHookNotFound) {
+		fsm.closeErr = fmt.Errorf("failed to remove broadcast hook %q: %w", hookName, err)
+		return fsm.closeErr
 	}
 
 	return nil

--- a/fsm_test.go
+++ b/fsm_test.go
@@ -2,16 +2,20 @@ package fsm
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"log/slog"
 	"os"
 	"runtime"
 	"slices"
+	"strings"
 	"sync"
 	"testing"
 	"testing/synctest"
 	"time"
 
 	"github.com/robbyt/go-fsm/v2/hooks"
+	"github.com/robbyt/go-fsm/v2/hooks/broadcast"
 	"github.com/robbyt/go-fsm/v2/transitions"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -112,6 +116,21 @@ func (m *mockCallbackExecutor) getReceivedContexts() []context.Context {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return append([]context.Context(nil), m.receivedContexts...)
+}
+
+// mustSubscribe registers ch on m and fails the test if registration errors.
+// It returns the unsubscribe handle, which most callers ignore because the test
+// context ends the subscription.
+func mustSubscribe(t *testing.T, m *Machine, ctx context.Context, ch chan string) {
+	t.Helper()
+
+	require.NoError(t, m.GetStateChan(ctx, ch))
+}
+
+// subscribeErr returns just the error from a subscription attempt, for tests
+// asserting on rejection.
+func subscribeErr(m *Machine, ctx context.Context, ch chan string) error {
+	return m.GetStateChan(ctx, ch)
 }
 
 // Unit tests with mocked dependencies
@@ -673,6 +692,7 @@ func TestFSM_GetStateChan(t *testing.T) {
 		//nolint:staticcheck // Intentionally testing nil context error
 		err = fsm.GetStateChan(nil, c)
 		require.Error(t, err)
+		require.ErrorIs(t, err, ErrInvalidConfiguration)
 		assert.Contains(t, err.Error(), "context cannot be nil")
 	})
 
@@ -688,6 +708,7 @@ func TestFSM_GetStateChan(t *testing.T) {
 		c := make(chan string, 1)
 		err = fsm.GetStateChan(ctx, c)
 		require.Error(t, err)
+		require.ErrorIs(t, err, ErrNoCallbackRegistry)
 		assert.Contains(t, err.Error(), "GetStateChan requires a callback registry")
 	})
 
@@ -704,6 +725,7 @@ func TestFSM_GetStateChan(t *testing.T) {
 		c := make(chan string, 1)
 		err = fsm.GetStateChan(ctx, c)
 		require.Error(t, err)
+		require.ErrorIs(t, err, ErrNoCallbackRegistry)
 		assert.Contains(t, err.Error(), "requires a callback registry that supports dynamic hook registration")
 	})
 
@@ -918,8 +940,8 @@ func TestGetStateChan_SharedRegistry(t *testing.T) {
 
 	ch1 := make(chan string, 10)
 	ch2 := make(chan string, 10)
-	require.NoError(t, m1.GetStateChan(ctx, ch1))
-	require.NoError(t, m2.GetStateChan(ctx, ch2)) // previously failed permanently
+	mustSubscribe(t, m1, ctx, ch1)
+	mustSubscribe(t, m2, ctx, ch2) // previously failed permanently
 
 	// Each subscriber receives its own machine's initial state.
 	assert.Equal(t, transitions.StatusNew, <-ch1)
@@ -966,7 +988,7 @@ func TestGetStateChan_InitialSendIsAtomic(t *testing.T) {
 	for i := range 500 {
 		ctx, cancel := context.WithCancel(context.Background())
 		ch := make(chan string, 256)
-		require.NoError(t, machine.GetStateChan(ctx, ch))
+		mustSubscribe(t, machine, ctx, ch)
 
 		// Collect the initial value plus the first broadcast.
 		var got []string
@@ -1073,4 +1095,593 @@ func TestFSM_IsTerminal(t *testing.T) {
 
 		assert.False(t, machine.IsTerminal(), "Unknown self-loops, so it is not terminal")
 	})
+}
+
+// TestGetStateChan_NilChannelRejected verifies that a nil channel is rejected
+// before any state is touched. Previously the nil channel fell through to the
+// initial-state send, which blocks forever on a nil channel while holding the
+// FSM read lock; with a non-cancellable context that permanently wedged every
+// Transition, SetState, and MarshalJSON call on the machine.
+func TestGetStateChan_NilChannelRejected(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Returns ErrNilStateChannel and leaves the machine usable", func(t *testing.T) {
+		reg, err := hooks.NewRegistry(hooks.WithTransitions(transitions.Typical))
+		require.NoError(t, err)
+		machine, err := New(transitions.StatusNew, transitions.Typical, WithCallbackRegistry(reg))
+		require.NoError(t, err)
+
+		err = machine.GetStateChan(context.Background(), nil)
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrNilStateChannel)
+
+		// The rejection happens before setup, so no broadcast hook was registered.
+		assert.Empty(t, reg.GetHooks())
+
+		// The read lock was never taken: transitions still work.
+		require.NoError(t, machine.Transition(transitions.StatusBooting))
+		assert.Equal(t, transitions.StatusBooting, machine.GetState())
+
+		// Setup was not consumed: a later valid subscription still succeeds.
+		ch := make(chan string, 1)
+		mustSubscribe(t, machine, t.Context(), ch)
+		assert.Equal(t, transitions.StatusBooting, <-ch)
+	})
+
+	t.Run("Spawns no goroutine and registers no subscriber", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			reg, err := hooks.NewRegistry(hooks.WithTransitions(transitions.Typical))
+			require.NoError(t, err)
+			machine, err := New(transitions.StatusNew, transitions.Typical, WithCallbackRegistry(reg))
+			require.NoError(t, err)
+
+			// context.Background() is deliberate: on the old code both this call
+			// and the manager's cleanup goroutine block on it forever, which the
+			// bubble reports as a deadlock.
+			require.ErrorIs(t, subscribeErr(machine, context.Background(), nil), ErrNilStateChannel)
+			synctest.Wait()
+
+			require.NoError(t, machine.Transition(transitions.StatusBooting))
+		})
+	})
+}
+
+// mockHookRegistrar implements HookRegistrar but deliberately NOT HookRemover,
+// to exercise Close against a callback executor that cannot remove hooks.
+type mockHookRegistrar struct {
+	*mockCallbackExecutor
+}
+
+func newMockHookRegistrar() *mockHookRegistrar {
+	return &mockHookRegistrar{mockCallbackExecutor: newMockCallbackExecutor()}
+}
+
+func (m *mockHookRegistrar) RegisterPostTransitionHook(hooks.PostTransitionHookConfig) error {
+	return nil
+}
+
+func (m *mockHookRegistrar) RegisterPreTransitionHook(hooks.PreTransitionHookConfig) error {
+	return nil
+}
+
+// broadcastHookNames returns the names of the broadcast hooks GetStateChan has
+// registered on reg, sorted.
+func broadcastHookNames(t *testing.T, reg *hooks.Registry) []string {
+	t.Helper()
+
+	var names []string
+	for _, info := range reg.GetHooks() {
+		if strings.HasPrefix(info.Name, "fsm.GetStateChan.") {
+			names = append(names, info.Name)
+		}
+	}
+	slices.Sort(names)
+	return names
+}
+
+// TestGetStateChan_HookNamesAreUniquePerMachine pins the broadcast hook naming
+// contract: each Machine uses its own process-unique id. The previous %p form
+// was not unique over time, because a garbage-collected Machine's address can be
+// reused by a later allocation sharing the same registry.
+func TestGetStateChan_HookNamesAreUniquePerMachine(t *testing.T) {
+	t.Parallel()
+
+	reg, err := hooks.NewRegistry(hooks.WithTransitions(transitions.Typical))
+	require.NoError(t, err)
+
+	m1, err := New(transitions.StatusNew, transitions.Typical, WithCallbackRegistry(reg))
+	require.NoError(t, err)
+	m2, err := New(transitions.StatusNew, transitions.Typical, WithCallbackRegistry(reg))
+	require.NoError(t, err)
+
+	mustSubscribe(t, m1, t.Context(), make(chan string, 1))
+	mustSubscribe(t, m2, t.Context(), make(chan string, 1))
+
+	names := broadcastHookNames(t, reg)
+	require.Len(t, names, 2)
+	assert.NotEqual(t, names[0], names[1])
+	assert.NotEqual(t, m1.hookName, m2.hookName)
+	assert.Equal(t, fmt.Sprintf("fsm.GetStateChan.%d", m1.id), m1.hookName)
+}
+
+// TestMachineClose_RemovesHookFromSharedRegistry verifies the core of the fix:
+// a Machine discarded from a shared registry can release its broadcast hook, so
+// it stops firing on every other Machine's transitions.
+func TestMachineClose_RemovesHookFromSharedRegistry(t *testing.T) {
+	t.Parallel()
+
+	reg, err := hooks.NewRegistry(hooks.WithTransitions(transitions.Typical))
+	require.NoError(t, err)
+
+	m1, err := New(transitions.StatusNew, transitions.Typical, WithCallbackRegistry(reg))
+	require.NoError(t, err)
+	m2, err := New(transitions.StatusNew, transitions.Typical, WithCallbackRegistry(reg))
+	require.NoError(t, err)
+
+	ch1 := make(chan string, 10)
+	ch2 := make(chan string, 10)
+	mustSubscribe(t, m1, t.Context(), ch1)
+	mustSubscribe(t, m2, t.Context(), ch2)
+	assert.Equal(t, transitions.StatusNew, <-ch1)
+	assert.Equal(t, transitions.StatusNew, <-ch2)
+
+	require.Len(t, broadcastHookNames(t, reg), 2)
+
+	m2Hook := m2.hookName
+	require.NoError(t, m1.Close())
+
+	// Only m2's hook survives.
+	assert.Equal(t, []string{m2Hook}, broadcastHookNames(t, reg))
+
+	// m1 still transitions, but no longer broadcasts.
+	require.NoError(t, m1.Transition(transitions.StatusBooting))
+	require.Never(t, func() bool {
+		select {
+		case <-ch1:
+			return true
+		default:
+			return false
+		}
+	}, 100*time.Millisecond, 10*time.Millisecond, "closed machine must not broadcast")
+
+	// m2 is unaffected.
+	require.NoError(t, m2.Transition(transitions.StatusBooting))
+	require.Eventually(t, func() bool {
+		select {
+		case state := <-ch2:
+			return assert.Equal(t, transitions.StatusBooting, state)
+		default:
+			return false
+		}
+	}, 100*time.Millisecond, 10*time.Millisecond, "the surviving machine must still broadcast")
+}
+
+// TestMachineClose_Idempotent verifies repeated Close calls are safe.
+func TestMachineClose_Idempotent(t *testing.T) {
+	t.Parallel()
+
+	reg, err := hooks.NewRegistry(hooks.WithTransitions(transitions.Typical))
+	require.NoError(t, err)
+	machine, err := New(transitions.StatusNew, transitions.Typical, WithCallbackRegistry(reg))
+	require.NoError(t, err)
+
+	mustSubscribe(t, machine, t.Context(), make(chan string, 1))
+	require.NoError(t, machine.Close())
+	require.NoError(t, machine.Close())
+	assert.Empty(t, broadcastHookNames(t, reg))
+}
+
+// TestMachineClose_BeforeGetStateChan verifies Close on a Machine that never
+// subscribed, and that GetStateChan is refused afterwards.
+func TestMachineClose_BeforeGetStateChan(t *testing.T) {
+	t.Parallel()
+
+	reg, err := hooks.NewRegistry(hooks.WithTransitions(transitions.Typical))
+	require.NoError(t, err)
+	machine, err := New(transitions.StatusNew, transitions.Typical, WithCallbackRegistry(reg))
+	require.NoError(t, err)
+
+	require.NoError(t, machine.Close())
+	assert.Empty(t, reg.GetHooks())
+
+	require.ErrorIs(t, subscribeErr(machine, t.Context(), make(chan string, 1)), ErrMachineClosed)
+}
+
+// TestMachineClose_MachineStaysUsable verifies that Close releases only the
+// subscription plumbing: state operations and caller-registered hooks continue
+// to work.
+func TestMachineClose_MachineStaysUsable(t *testing.T) {
+	t.Parallel()
+
+	reg, err := hooks.NewRegistry(hooks.WithTransitions(transitions.Typical))
+	require.NoError(t, err)
+
+	userHookCalls := 0
+	require.NoError(t, reg.RegisterPostTransitionHook(hooks.PostTransitionHookConfig{
+		Name: "user-hook",
+		From: []string{"*"},
+		To:   []string{"*"},
+		Action: func(ctx context.Context, from, to string) {
+			userHookCalls++
+		},
+	}))
+
+	machine, err := New(transitions.StatusNew, transitions.Typical, WithCallbackRegistry(reg))
+	require.NoError(t, err)
+	mustSubscribe(t, machine, t.Context(), make(chan string, 1))
+	require.NoError(t, machine.Close())
+
+	require.NoError(t, machine.Transition(transitions.StatusBooting))
+	assert.Equal(t, transitions.StatusBooting, machine.GetState())
+	require.NoError(t, machine.SetState(transitions.StatusRunning))
+	assert.Equal(t, transitions.StatusRunning, machine.GetState())
+	assert.Equal(t, 2, userHookCalls, "caller-registered hooks must still fire after Close")
+
+	// The caller's own hook is untouched by Close.
+	assert.Len(t, reg.GetHooks(), 1)
+}
+
+// TestMachineClose_RegistrarWithoutRemoveHook verifies that a callback executor
+// which cannot remove hooks produces an error naming the orphaned hook, while
+// still marking the machine closed and releasing its subscribers.
+func TestMachineClose_RegistrarWithoutRemoveHook(t *testing.T) {
+	t.Parallel()
+
+	registrar := newMockHookRegistrar()
+	mockDB := newMockTransitionDB(map[string][]string{
+		"state1": {"state2"},
+		"state2": {},
+	})
+
+	machine, err := New("state1", mockDB, WithCallbackRegistry(registrar))
+	require.NoError(t, err)
+
+	ch := make(chan string, 1)
+	mustSubscribe(t, machine, t.Context(), ch)
+
+	hookName := machine.hookName // Close clears it, so capture it first
+
+	err = machine.Close()
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrInvalidConfiguration)
+	assert.Contains(t, err.Error(), hookName, "the orphaned hook must be named so it can be removed by hand")
+
+	// Closed regardless of the failure, and the error is remembered.
+	require.ErrorIs(t, subscribeErr(machine, t.Context(), make(chan string, 1)), ErrMachineClosed)
+	assert.Equal(t, err.Error(), machine.Close().Error(), "the teardown error must be cached, not forgotten")
+}
+
+// TestGetStateChan_CancellationStopsDelivery verifies that cancelling the
+// subscription's context stops delivery and frees the channel for re-use. This
+// is the only per-subscription teardown path: the caller owns the channel, and
+// scopes its lifetime with the context it subscribed under.
+func TestGetStateChan_CancellationStopsDelivery(t *testing.T) {
+	t.Parallel()
+
+	reg, err := hooks.NewRegistry(hooks.WithTransitions(transitions.Typical))
+	require.NoError(t, err)
+	machine, err := New(transitions.StatusNew, transitions.Typical, WithCallbackRegistry(reg))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if err := machine.Close(); err != nil {
+			t.Errorf("Close returned an error: %v", err)
+		}
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ch := make(chan string, 10)
+	mustSubscribe(t, machine, ctx, ch)
+	assert.Equal(t, transitions.StatusNew, <-ch)
+
+	require.NoError(t, machine.Transition(transitions.StatusBooting))
+	require.Eventually(t, func() bool {
+		select {
+		case state := <-ch:
+			return assert.Equal(t, transitions.StatusBooting, state)
+		default:
+			return false
+		}
+	}, 100*time.Millisecond, 10*time.Millisecond, "expected the live subscriber to receive the transition")
+
+	cancel()
+
+	// Teardown runs on its own goroutine, so wait for delivery to actually stop
+	// before asserting silence.
+	require.Eventually(t, func() bool {
+		if err := machine.Transition(transitions.StatusRunning); err != nil {
+			return false
+		}
+		if err := machine.SetState(transitions.StatusRunning); err != nil {
+			return false
+		}
+		select {
+		case <-ch:
+			return false
+		default:
+			return true
+		}
+	}, 500*time.Millisecond, 10*time.Millisecond, "cancelled subscriber should stop receiving states")
+
+	// The channel is free to subscribe again under a fresh context.
+	mustSubscribe(t, machine, t.Context(), ch)
+	assert.Equal(t, transitions.StatusRunning, <-ch)
+}
+
+// TestGetStateChan_DuplicateChannelRejectedOnMachine verifies that the
+// duplicate-subscription sentinel propagates through Machine.GetStateChan.
+func TestGetStateChan_DuplicateChannelRejectedOnMachine(t *testing.T) {
+	t.Parallel()
+
+	reg, err := hooks.NewRegistry(hooks.WithTransitions(transitions.Typical))
+	require.NoError(t, err)
+	machine, err := New(transitions.StatusNew, transitions.Typical, WithCallbackRegistry(reg))
+	require.NoError(t, err)
+
+	ch := make(chan string, 10)
+	mustSubscribe(t, machine, t.Context(), ch)
+	assert.Equal(t, transitions.StatusNew, <-ch)
+
+	require.ErrorIs(t, subscribeErr(machine, t.Context(), ch), broadcast.ErrChannelAlreadySubscribed)
+
+	// The first subscription is still live, and receives exactly one copy.
+	require.NoError(t, machine.Transition(transitions.StatusBooting))
+	require.Eventually(t, func() bool {
+		select {
+		case state := <-ch:
+			return assert.Equal(t, transitions.StatusBooting, state)
+		default:
+			return false
+		}
+	}, 100*time.Millisecond, 10*time.Millisecond, "the original subscription should still be live")
+	assert.Empty(t, ch, "state should be delivered exactly once")
+}
+
+// TestGetStateChan_SameChannelOnTwoMachinesAllowed verifies that the
+// duplicate-subscription rule is per-Machine, not global.
+func TestGetStateChan_SameChannelOnTwoMachinesAllowed(t *testing.T) {
+	t.Parallel()
+
+	reg1, err := hooks.NewRegistry(hooks.WithTransitions(transitions.Typical))
+	require.NoError(t, err)
+	reg2, err := hooks.NewRegistry(hooks.WithTransitions(transitions.Typical))
+	require.NoError(t, err)
+
+	m1, err := New(transitions.StatusNew, transitions.Typical, WithCallbackRegistry(reg1))
+	require.NoError(t, err)
+	m2, err := New(transitions.StatusNew, transitions.Typical, WithCallbackRegistry(reg2))
+	require.NoError(t, err)
+
+	ch := make(chan string, 10)
+	mustSubscribe(t, m1, t.Context(), ch)
+	mustSubscribe(t, m2, t.Context(), ch)
+
+	// Both initial states arrive on the shared channel.
+	assert.Equal(t, transitions.StatusNew, <-ch)
+	assert.Equal(t, transitions.StatusNew, <-ch)
+}
+
+// TestGetStateChan_RetriesAfterFailedSetup verifies that a failed hook
+// registration is no longer cached permanently. The sync.Once this replaced
+// stored the error forever, so one transient failure poisoned the machine.
+func TestGetStateChan_RetriesAfterFailedSetup(t *testing.T) {
+	t.Parallel()
+
+	// A registry without WithTransitions cannot accept the wildcard broadcast hook.
+	badReg, err := hooks.NewRegistry()
+	require.NoError(t, err)
+	machine, err := New(transitions.StatusNew, transitions.Typical, WithCallbackRegistry(badReg))
+	require.NoError(t, err)
+
+	err1 := machine.GetStateChan(t.Context(), make(chan string, 1))
+	require.Error(t, err1)
+	assert.Contains(t, err1.Error(), "wildcard")
+
+	// The second attempt genuinely retries rather than replaying a cached error.
+	err2 := machine.GetStateChan(t.Context(), make(chan string, 1))
+	require.Error(t, err2)
+	assert.Equal(t, err1.Error(), err2.Error())
+
+	// A machine with a good registry is unaffected.
+	goodReg, err := hooks.NewRegistry(hooks.WithTransitions(transitions.Typical))
+	require.NoError(t, err)
+	good, err := New(transitions.StatusNew, transitions.Typical, WithCallbackRegistry(goodReg))
+	require.NoError(t, err)
+	mustSubscribe(t, good, t.Context(), make(chan string, 1))
+}
+
+// TestMachineClose_ConcurrentCalls verifies that concurrent Close calls agree on
+// one outcome and remove the hook exactly once.
+func TestMachineClose_ConcurrentCalls(t *testing.T) {
+	t.Parallel()
+
+	reg, err := hooks.NewRegistry(hooks.WithTransitions(transitions.Typical))
+	require.NoError(t, err)
+	machine, err := New(transitions.StatusNew, transitions.Typical, WithCallbackRegistry(reg))
+	require.NoError(t, err)
+	mustSubscribe(t, machine, t.Context(), make(chan string, 1))
+
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Go(func() {
+			if err := machine.Close(); err != nil {
+				t.Errorf("concurrent Close returned an error: %v", err)
+			}
+		})
+	}
+	wg.Wait()
+
+	assert.Empty(t, broadcastHookNames(t, reg))
+}
+
+// TestMachineClose_RacingGetStateChan verifies that Close and GetStateChan
+// cannot interleave into a subscriber attached to a manager Close has already
+// detached. Either GetStateChan wins and its subscription is then released by
+// Close, or Close wins and GetStateChan is refused.
+func TestMachineClose_RacingGetStateChan(t *testing.T) {
+	t.Parallel()
+
+	for range 200 {
+		reg, err := hooks.NewRegistry(hooks.WithTransitions(transitions.Typical))
+		require.NoError(t, err)
+		machine, err := New(transitions.StatusNew, transitions.Typical, WithCallbackRegistry(reg))
+		require.NoError(t, err)
+
+		ch := make(chan string, 1)
+
+		var wg sync.WaitGroup
+		var subErr error
+		wg.Go(func() { subErr = machine.GetStateChan(context.Background(), ch) })
+		wg.Go(func() {
+			// The racing Close may legitimately be the first or second caller;
+			// either way it must not error.
+			if err := machine.Close(); err != nil {
+				t.Errorf("racing Close returned an error: %v", err)
+			}
+		})
+		wg.Wait()
+
+		if subErr != nil {
+			require.ErrorIs(t, subErr, ErrMachineClosed)
+		}
+		// Either way the machine ends up closed with no lingering hook.
+		require.NoError(t, machine.Close())
+		assert.Empty(t, broadcastHookNames(t, reg))
+	}
+}
+
+// TestMachineClose_FromWithinAHook verifies the documented guarantee that Close
+// is safe to call from a transition hook: it never takes the FSM mutex, and the
+// hook executors release the registry lock before running hooks.
+func TestMachineClose_FromWithinAHook(t *testing.T) {
+	t.Parallel()
+
+	reg, err := hooks.NewRegistry(hooks.WithTransitions(transitions.Typical))
+	require.NoError(t, err)
+
+	var machine *Machine
+	closeErr := make(chan error, 1)
+	require.NoError(t, reg.RegisterPostTransitionHook(hooks.PostTransitionHookConfig{
+		Name: "closer",
+		From: []string{"*"},
+		To:   []string{transitions.StatusBooting},
+		Action: func(ctx context.Context, from, to string) {
+			closeErr <- machine.Close()
+		},
+	}))
+
+	machine, err = New(transitions.StatusNew, transitions.Typical, WithCallbackRegistry(reg))
+	require.NoError(t, err)
+	mustSubscribe(t, machine, t.Context(), make(chan string, 10))
+
+	// Must not deadlock.
+	require.NoError(t, machine.Transition(transitions.StatusBooting))
+	require.NoError(t, <-closeErr)
+
+	assert.Empty(t, broadcastHookNames(t, reg))
+	// The machine remains usable for state operations.
+	require.NoError(t, machine.Transition(transitions.StatusRunning))
+}
+
+// TestGetStateChan_InitialSendCancelledMidFlight covers the initial-send
+// cancellation path. Its sibling, TestGetStateChan_InitialSendRespectsContext,
+// pre-cancels the context and so is now rejected by the broadcast manager before
+// the send is ever reached; this exercises a cancellation that lands while the
+// send is genuinely blocked on a full channel.
+func TestGetStateChan_InitialSendCancelledMidFlight(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		reg, err := hooks.NewRegistry(hooks.WithTransitions(transitions.Typical))
+		require.NoError(t, err)
+		machine, err := New(transitions.StatusNew, transitions.Typical, WithCallbackRegistry(reg))
+		require.NoError(t, err)
+
+		ctx, cancel := context.WithCancel(t.Context())
+		ch := make(chan string) // unbuffered, no reader: the initial send blocks
+
+		var subErr error
+		done := make(chan struct{})
+		go func() {
+			subErr = machine.GetStateChan(ctx, ch)
+			close(done)
+		}()
+
+		// Let the subscription reach the blocked send before cancelling.
+		synctest.Wait()
+		select {
+		case <-done:
+			t.Fatal("GetStateChan returned before the initial send could block")
+		default:
+		}
+
+		cancel()
+		synctest.Wait()
+
+		<-done
+		require.ErrorIs(t, subErr, context.Canceled)
+	})
+}
+
+// mockFailingRemover implements HookRegistrar and HookRemover, with a RemoveHook
+// that always fails, to cover Close's hook-removal error path.
+type mockFailingRemover struct {
+	*mockCallbackExecutor
+	removeErr error
+}
+
+func (m *mockFailingRemover) RegisterPostTransitionHook(hooks.PostTransitionHookConfig) error {
+	return nil
+}
+
+func (m *mockFailingRemover) RegisterPreTransitionHook(hooks.PreTransitionHookConfig) error {
+	return nil
+}
+
+func (m *mockFailingRemover) RemoveHook(string) error { return m.removeErr }
+
+// TestMachineClose_HookRemovalFails verifies that a registry which accepts the
+// hook but fails to remove it surfaces the failure, names the orphaned hook, and
+// still leaves the machine closed rather than half-open.
+func TestMachineClose_HookRemovalFails(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("registry exploded")
+	registrar := &mockFailingRemover{
+		mockCallbackExecutor: newMockCallbackExecutor(),
+		removeErr:            sentinel,
+	}
+	mockDB := newMockTransitionDB(map[string][]string{
+		"state1": {"state2"},
+		"state2": {},
+	})
+
+	machine, err := New("state1", mockDB, WithCallbackRegistry(registrar))
+	require.NoError(t, err)
+	mustSubscribe(t, machine, t.Context(), make(chan string, 1))
+
+	hookName := machine.hookName
+
+	err = machine.Close()
+	require.ErrorIs(t, err, sentinel)
+	assert.Contains(t, err.Error(), hookName)
+
+	// Closed despite the failure, and the error is remembered rather than
+	// silently forgotten on the next call.
+	require.ErrorIs(t, subscribeErr(machine, t.Context(), make(chan string, 1)), ErrMachineClosed)
+	require.ErrorIs(t, machine.Close(), sentinel)
+}
+
+// TestMachineClose_ToleratesAlreadyRemovedHook verifies that a hook the caller
+// removed themselves is not treated as a Close failure.
+func TestMachineClose_ToleratesAlreadyRemovedHook(t *testing.T) {
+	t.Parallel()
+
+	reg, err := hooks.NewRegistry(hooks.WithTransitions(transitions.Typical))
+	require.NoError(t, err)
+	machine, err := New(transitions.StatusNew, transitions.Typical, WithCallbackRegistry(reg))
+	require.NoError(t, err)
+	mustSubscribe(t, machine, t.Context(), make(chan string, 1))
+
+	require.NoError(t, reg.RemoveHook(machine.hookName))
+	require.NoError(t, machine.Close(), "a hook already removed by the caller is not a Close failure")
 }

--- a/hooks/broadcast/README.md
+++ b/hooks/broadcast/README.md
@@ -38,18 +38,48 @@ machine, _ := fsm.New(transitions.StatusNew, transitions.Typical,
 	fsm.WithCallbackRegistry(registry))
 
 // Subscribe to state changes
-ctx := context.Background()
+ctx, cancel := context.WithCancel(context.Background())
+defer cancel()
+
 stateChan, _ := manager.GetStateChan(ctx)
 
 for state := range stateChan {
-	// Handle state change
+	// Handle state change; the loop ends when cancel() closes the channel.
+	_ = state
 }
 ```
+
+## Ending a Subscription
+
+A subscription ends when its context is cancelled, or when `UnsubscribeAll`
+releases every subscriber at once:
+
+```go
+// Ends every subscription, e.g. when tearing down whatever owns this manager.
+manager.UnsubscribeAll()
+```
+
+A manager-owned channel — one created by `WithBufferSize`, or by default — is
+closed when its subscription ends, so a `for range` over it terminates. A channel
+supplied via `WithCustomChannel` belongs to its caller: the manager never closes
+it, and you must not close it while it is still subscribed.
+
+Subscribing with a non-cancellable context such as `context.Background()` is
+supported and costs nothing, but leaves `UnsubscribeAll` as the only way to end
+the subscription, so a subscriber that is simply dropped stays registered for the
+life of the manager. Prefer a cancellable context. An already-cancelled context
+is rejected, and a channel may hold only one live subscription per manager
+(`ErrChannelAlreadySubscribed`).
 
 ## Delivery Modes
 
 - **Best-effort (default)**: Non-blocking, drops messages if channel is full
 - **Timeout**: `WithTimeout(5*time.Second)` - blocks up to duration
 - **Guaranteed**: `WithTimeout(-1)` - blocks indefinitely until delivered
+
+> **Note:** when this manager is driven by a post-transition hook, broadcasts run
+> while the FSM write lock is held. A slow subscriber therefore delays *every*
+> transition for up to the configured timeout, and guaranteed delivery to a
+> subscriber that never drains halts the machine entirely.
 
 See [godoc](https://pkg.go.dev/github.com/robbyt/go-fsm/v2/hooks/broadcast) for details.

--- a/hooks/broadcast/errors.go
+++ b/hooks/broadcast/errors.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2024 Robert Terhaar <robbyt@robbyt.net>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package broadcast
+
+import "errors"
+
+var (
+	// ErrNilContext is returned when GetStateChan is called with a nil context
+	ErrNilContext = errors.New("context cannot be nil")
+
+	// ErrChannelAlreadySubscribed is returned by GetStateChan when the given
+	// channel already has a live subscription on this manager
+	ErrChannelAlreadySubscribed = errors.New("channel is already subscribed")
+)

--- a/hooks/broadcast/manager.go
+++ b/hooks/broadcast/manager.go
@@ -25,11 +25,86 @@ import (
 	"time"
 )
 
+// subscription is the manager's per-subscriber bookkeeping, built in
+// GetStateChan once the options have been applied. Config remains purely the
+// option target; everything the manager needs at runtime lives here.
+type subscription struct {
+	ch              chan string
+	timeout         time.Duration
+	externalChannel bool
+
+	// ctxDone is the subscriber's context cancellation signal. Broadcast selects
+	// on it so a blocking send to a subscriber whose context has been cancelled
+	// is abandoned instead of holding the manager mutex forever. It is nil for a
+	// non-cancellable context, and a nil channel is never ready.
+	ctxDone <-chan struct{}
+
+	// departed is closed exactly once when this subscription ends, by either
+	// context cancellation or an explicit unsubscribe. Broadcast selects on it
+	// alongside ctxDone so an explicit unsubscribe can release a parked send.
+	departed   chan struct{}
+	signalOnce sync.Once
+
+	// stopAfterFunc releases this subscription's context.AfterFunc association.
+	// It is assigned under Manager.mu before the subscription is published, and
+	// is only ever read by UnsubscribeAll, which reaches the subscription through
+	// the map and so observes the write. depart must never call it: on the
+	// context path depart IS the callback.
+	stopAfterFunc func() bool
+}
+
+// key returns the map key for this subscription. Subscribers are keyed by the
+// receive side of the channel, which is the form GetStateChan returns and the
+// form a duplicate-registration check needs to compare against.
+func (s *subscription) key() <-chan string {
+	return s.ch
+}
+
+// signalDepart marks this subscription as ended, releasing any broadcast
+// currently parked on a blocking send to it. Safe to call repeatedly and from
+// any goroutine; it deliberately takes no lock, because callers must be able to
+// signal before contending for the manager mutex.
+func (s *subscription) signalDepart() {
+	s.signalOnce.Do(func() { close(s.departed) })
+}
+
+// live reports whether this subscription still receives broadcasts. Departure
+// counts as dead as well as context cancellation: teardown signals departure
+// before it can acquire the manager mutex, and a GetStateChan that wins the
+// mutex in that window must see the slot as free rather than rejecting the new
+// registration as a duplicate.
+func (s *subscription) live() bool {
+	select {
+	case <-s.departed:
+		return false
+	case <-s.ctxDone: // nil for a non-cancellable context, and never ready
+		return false
+	default:
+		return true
+	}
+}
+
 // Manager handles state change notifications to subscribers.
 type Manager struct {
-	mu          sync.Mutex
+	mu sync.Mutex
+
+	// subscribers maps <-chan string to *subscription.
+	//
+	// The locking discipline here is deliberately path-dependent, and a future
+	// change to a plain map must preserve both halves:
+	//
+	//   - GetStateChan does its duplicate Load and its Store under mu, because
+	//     the pair has to be atomic or two concurrent registrations of the same
+	//     channel both succeed.
+	//   - Unsubscribe and UnsubscribeAll's first pass read WITHOUT mu, because
+	//     they must signal departure before contending for a mutex that a
+	//     broadcast parked on a blocking send is holding.
+	//
+	// A plain map would therefore need its own second mutex for the unlocked
+	// reads; reusing mu for them reintroduces the deadlock.
 	subscribers sync.Map
-	logger      *slog.Logger
+
+	logger *slog.Logger
 }
 
 // NewManager creates a new broadcast manager.
@@ -43,12 +118,33 @@ func NewManager(handler slog.Handler) *Manager {
 }
 
 // GetStateChan returns a channel that receives state change notifications.
-// The channel is automatically closed when ctx is cancelled.
 // Use functional options to customize buffer size, timeout behavior, or provide a custom channel.
 // Returns an error if ctx is nil.
+//
+// Cancelling ctx ends the subscription; UnsubscribeAll ends every subscription
+// at once. A manager-owned channel is closed when the subscription ends; a
+// channel supplied via WithCustomChannel belongs to its caller, who is
+// responsible for closing it and must not do so while it is still subscribed.
+//
+// Passing a non-cancellable context (context.Background()) is supported and
+// costs nothing, but leaves UnsubscribeAll as the only way to end the
+// subscription, so a subscriber that is simply dropped stays registered for the
+// lifetime of the manager. Prefer a cancellable context. An already-cancelled
+// context is rejected.
+//
+// A channel may hold only one live subscription per manager: subscribing the
+// same channel twice returns ErrChannelAlreadySubscribed. Re-subscribing a
+// channel whose previous subscription has ended is allowed, as is subscribing
+// one channel to several managers.
 func (m *Manager) GetStateChan(ctx context.Context, opts ...Option) (<-chan string, error) {
 	if ctx == nil {
-		return nil, fmt.Errorf("context cannot be nil")
+		return nil, ErrNilContext
+	}
+
+	// Reject an already-cancelled context rather than registering a subscription
+	// that is dead on arrival and would be torn down again immediately.
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("cannot subscribe with a cancelled context: %w", err)
 	}
 
 	config := &Config{}
@@ -57,36 +153,94 @@ func (m *Manager) GetStateChan(ctx context.Context, opts ...Option) (<-chan stri
 		opt(config)
 	}
 
-	// Record the subscriber's cancellation signal so Broadcast can abandon a
-	// blocking send once this subscriber's context is cancelled.
-	config.done = ctx.Done()
+	sub := &subscription{
+		timeout:         config.timeout,
+		externalChannel: config.externalChannel,
+		ctxDone:         ctx.Done(),
+		departed:        make(chan struct{}),
+	}
 
-	var ch chan string
 	if config.channel != nil {
-		ch = config.channel
+		sub.ch = config.channel
 	} else {
 		// Fall back to a manager-owned channel. Reset externalChannel in case a
 		// caller passed WithCustomChannel(nil), which would otherwise leave it
-		// true and prevent the cleanup goroutine from closing this channel.
-		ch = make(chan string, 1)
-		config.externalChannel = false
+		// true and prevent cleanup from closing this channel.
+		sub.ch = make(chan string, 1)
+		sub.externalChannel = false
 	}
 
-	// Register subscriber
+	// Register the subscriber and arm context cleanup as one critical section.
+	//
+	// context.AfterFunc runs its callback immediately, on a fresh goroutine, when
+	// the context is already cancelled -- so arming it outside the lock would let
+	// that callback finish departing before the Store below published the
+	// subscription, leaving a departed (and possibly closed) entry in the map.
+	// Holding m.mu across arm-and-store closes that window: depart signals
+	// without a lock but cannot reach its CompareAndDelete until we release, at
+	// which point it correctly removes what we just stored.
+	//
+	// AfterFunc also replaces a `go func() { <-ctx.Done(); ... }()` cleanup
+	// goroutine. For a non-cancellable context (context.Background()) it
+	// registers nothing and starts nothing, so such a subscriber no longer leaks
+	// a parked goroutine; it lives until Unsubscribe or UnsubscribeAll.
+	//
+	// The duplicate check shares this critical section: splitting it from the
+	// Store would let two concurrent registrations of the same channel both pass.
 	m.mu.Lock()
-	m.subscribers.Store(ch, config)
+	if value, loaded := m.subscribers.Load(sub.key()); loaded {
+		if existing, ok := value.(*subscription); ok && existing.live() {
+			m.mu.Unlock()
+			return nil, ErrChannelAlreadySubscribed
+		}
+		// The entry is dead: its context was cancelled, or an unsubscribe
+		// signalled departure and is still waiting for this mutex. Take the slot
+		// over -- depart uses CompareAndDelete, so the older teardown cannot
+		// evict us.
+	}
+	sub.stopAfterFunc = context.AfterFunc(ctx, func() { m.depart(sub) })
+	m.subscribers.Store(sub.key(), sub)
 	m.mu.Unlock()
 
-	// Handle cleanup when context is cancelled
-	go func() {
-		<-ctx.Done()
-		m.unsubscribe(ch)
-		if !config.externalChannel {
-			close(ch)
-		}
-	}()
+	return sub.ch, nil
+}
 
-	return ch, nil
+// UnsubscribeAll ends every current subscription. It is used to release all
+// subscribers at once when tearing down whatever owns this manager.
+//
+// Unlike a context cancellation, UnsubscribeAll cannot be delayed by the broadcast it is
+// trying to release: it signals every subscription it can see before acquiring
+// the manager mutex, so any parked send has already been given its exit.
+//
+// A subscription created concurrently with UnsubscribeAll is included if and
+// only if it completed registration before the second pass acquired the mutex.
+func (m *Manager) UnsubscribeAll() {
+	// Phase 1: signal without the mutex, freeing any parked broadcast so that
+	// phase 2 can acquire m.mu.
+	seen := make(map[*subscription]struct{})
+	for sub := range m.iterSubscribers() {
+		sub.signalDepart()
+		seen[sub] = struct{}{}
+	}
+
+	// Phase 2: under the mutex, remove everything still registered. Ranging
+	// again picks up any subscription that won the mutex ahead of us.
+	m.mu.Lock()
+	for sub := range m.iterSubscribers() {
+		sub.signalDepart()
+		seen[sub] = struct{}{}
+		if m.subscribers.CompareAndDelete(sub.key(), sub) && !sub.externalChannel {
+			close(sub.ch)
+		}
+	}
+	m.mu.Unlock()
+
+	// Phase 3: release the context associations for everything either pass saw.
+	// A take-over can make phase 1 observe an old record and phase 2 its
+	// replacement, so both need stopping.
+	for sub := range seen {
+		sub.stopAfterFunc()
+	}
 }
 
 // Broadcast sends the state to all subscriber channels.
@@ -106,14 +260,17 @@ func (m *Manager) Broadcast(state string) {
 
 	var wg sync.WaitGroup
 
-	for ch, config := range m.iterSubscribers() {
-		// done is the subscriber's context cancellation signal. Selecting on it
-		// in the blocking branches ensures a subscriber that has gone away (its
-		// context was cancelled) cannot block the broadcast indefinitely while
-		// the manager mutex is held, which would otherwise deadlock unsubscribe
-		// and every future Broadcast.
-		done := config.done
-		if config.timeout < 0 {
+	for sub := range m.iterSubscribers() {
+		ch := sub.ch
+		// departed and ctxDone are the subscriber's departure signals. Selecting
+		// on them in the blocking branches ensures a subscriber that has gone
+		// away -- its context was cancelled, or it was explicitly unsubscribed --
+		// cannot block the broadcast indefinitely while the manager mutex is
+		// held, which would otherwise deadlock departure and every future
+		// Broadcast.
+		done := sub.ctxDone
+		departed := sub.departed
+		if sub.timeout < 0 {
 			// Negative timeout: block until delivered or the subscriber departs
 			// (guaranteed delivery for live subscribers).
 			wg.Go(func() {
@@ -122,11 +279,13 @@ func (m *Manager) Broadcast(state string) {
 					logger.Debug("State delivered to guaranteed delivery subscriber")
 				case <-done:
 					logger.Debug("Guaranteed-delivery subscriber departed before delivery; aborting send")
+				case <-departed:
+					logger.Debug("Guaranteed-delivery subscriber unsubscribed before delivery; aborting send")
 				}
 			})
-		} else if config.timeout > 0 {
+		} else if sub.timeout > 0 {
 			// Positive timeout: block up to timeout duration
-			timeout := config.timeout
+			timeout := sub.timeout
 			wg.Go(func() {
 				select {
 				case ch <- state:
@@ -163,29 +322,42 @@ func (m *Manager) BroadcastHook(_ context.Context, _, to string) {
 	m.Broadcast(to)
 }
 
-// unsubscribe removes a channel from receiving broadcasts.
-func (m *Manager) unsubscribe(ch chan string) {
+// depart ends a subscription: it releases any in-flight blocking send to it,
+// removes it from the subscriber set, and closes the channel when the manager
+// owns it. Idempotent and safe to call from any goroutine.
+//
+// The ordering is load-bearing. departed is closed BEFORE m.mu is acquired:
+// Broadcast holds m.mu for the whole broadcast and may be parked in a blocking
+// send to this subscriber, so signalling first lets that send abort and the
+// mutex drop. Acquiring m.mu afterwards is what makes removal synchronous --
+// once depart returns, no broadcast is sending on this channel.
+func (m *Manager) depart(sub *subscription) {
+	sub.signalDepart()
+
 	m.mu.Lock()
-	m.subscribers.Delete(ch)
-	m.mu.Unlock()
+	defer m.mu.Unlock()
+
+	// CompareAndDelete rather than Delete: the same channel may already have been
+	// re-subscribed under a new subscription, and a late departure must neither
+	// evict that newer entry nor close the channel it is now using.
+	if m.subscribers.CompareAndDelete(sub.key(), sub) && !sub.externalChannel {
+		// Closing under m.mu is the send/close barrier: broadcasts hold the same
+		// mutex and wait for their send goroutines, so none is in flight here.
+		close(sub.ch)
+	}
 }
 
-// iterSubscribers returns a sequence of all subscriber channels and their configs.
-func (m *Manager) iterSubscribers() iter.Seq2[chan string, *Config] {
-	return func(yield func(chan string, *Config) bool) {
-		m.subscribers.Range(func(key, value any) bool {
-			ch, ok := key.(chan string)
+// iterSubscribers returns a sequence of all current subscriptions.
+func (m *Manager) iterSubscribers() iter.Seq[*subscription] {
+	return func(yield func(*subscription) bool) {
+		m.subscribers.Range(func(_, value any) bool {
+			sub, ok := value.(*subscription)
 			if !ok {
+				m.logger.Error("Invalid subscriber type; skipping subscriber")
 				return true
 			}
 
-			config, ok := value.(*Config)
-			if !ok {
-				m.logger.Error("Invalid subscriber config type; skipping subscriber")
-				return true
-			}
-
-			return yield(ch, config)
+			return yield(sub)
 		})
 	}
 }

--- a/hooks/broadcast/manager_test.go
+++ b/hooks/broadcast/manager_test.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"log/slog"
 	"os"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -595,5 +597,276 @@ func TestGetStateChan_NilCustomChannelIsManagerOwned(t *testing.T) {
 		assert.False(t, ok, "manager-owned channel should be closed after context cancellation")
 	case <-time.After(time.Second):
 		t.Fatal("channel was not closed after cancellation; nil custom channel was wrongly treated as external")
+	}
+}
+
+// TestGetStateChan_BackgroundContextSpawnsNoGoroutine verifies that subscribing
+// with a non-cancellable context does not start a per-subscriber cleanup
+// goroutine. Previously every GetStateChan spawned `go func(){ <-ctx.Done(); ...
+// }()`, which for context.Background() parked forever: the goroutine and its map
+// entry leaked for the life of the process.
+func TestGetStateChan_BackgroundContextSpawnsNoGoroutine(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		manager := broadcast.NewManager(newTestLogger().Handler())
+
+		for range 3 {
+			ch, err := manager.GetStateChan(context.Background(), broadcast.WithBufferSize(1))
+			require.NoError(t, err)
+			require.NotNil(t, ch)
+		}
+
+		// On the old code three goroutines are durably blocked on a nil Done()
+		// channel here, and the bubble fails with a deadlock.
+		synctest.Wait()
+
+		manager.UnsubscribeAll()
+	})
+}
+
+// TestUnsubscribeAll_EndsEverySubscriptionEvenWhenBroadcastIsBlocked verifies
+// that UnsubscribeAll releases a parked broadcast and clears every subscriber,
+// closing the manager-owned ones.
+func TestUnsubscribeAll_EndsEverySubscriptionEvenWhenBroadcastIsBlocked(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		manager := broadcast.NewManager(newTestLogger().Handler())
+
+		blocked := make(chan string, 1)
+		_, err := manager.GetStateChan(
+			context.Background(),
+			broadcast.WithCustomChannel(blocked),
+			broadcast.WithTimeout(-1),
+		)
+		require.NoError(t, err)
+
+		owned, err := manager.GetStateChan(context.Background(), broadcast.WithBufferSize(1))
+		require.NoError(t, err)
+
+		manager.Broadcast("first")
+
+		broadcastDone := false
+		go func() {
+			manager.Broadcast("second")
+			broadcastDone = true
+		}()
+
+		synctest.Wait()
+		require.False(t, broadcastDone, "broadcast should be parked on the full channel")
+
+		manager.UnsubscribeAll()
+
+		synctest.Wait()
+		assert.True(t, broadcastDone, "UnsubscribeAll should release the parked broadcast")
+
+		// Drain any buffered value, then confirm the manager-owned channel closed.
+		for range len(owned) {
+			<-owned
+		}
+		_, open := <-owned
+		assert.False(t, open, "manager-owned channel should be closed by UnsubscribeAll")
+
+		// The blocked subscriber was released, so its channel subscribes afresh
+		// rather than being rejected as a duplicate.
+		_, err = manager.GetStateChan(context.Background(), broadcast.WithCustomChannel(blocked))
+		require.NoError(t, err)
+	})
+}
+
+// TestGetStateChan_DuplicateChannelRejected verifies that a channel can hold
+// only one live subscription per manager. Subscribers are keyed by channel, so
+// a second registration used to silently overwrite the first's config and spawn
+// a second cleanup goroutine; cancelling the FIRST context then deleted the one
+// map entry and the second, still-live subscription stopped receiving with no
+// error.
+func TestGetStateChan_DuplicateChannelRejected(t *testing.T) {
+	t.Parallel()
+
+	manager := broadcast.NewManager(newTestLogger().Handler())
+	ch := make(chan string, 10)
+
+	ctx1, cancel1 := context.WithCancel(t.Context())
+	_, err := manager.GetStateChan(ctx1, broadcast.WithCustomChannel(ch))
+	require.NoError(t, err)
+
+	_, err = manager.GetStateChan(t.Context(), broadcast.WithCustomChannel(ch))
+	require.ErrorIs(t, err, broadcast.ErrChannelAlreadySubscribed)
+
+	// The rejected registration left the first subscription intact.
+	manager.Broadcast("StateA")
+	require.Eventually(t, func() bool {
+		select {
+		case state := <-ch:
+			return assert.Equal(t, "StateA", state)
+		default:
+			return false
+		}
+	}, 100*time.Millisecond, 10*time.Millisecond, "the original subscription should still be live")
+
+	// Exactly one copy: a duplicate registration would have delivered twice.
+	require.Never(t, func() bool {
+		select {
+		case <-ch:
+			return true
+		default:
+			return false
+		}
+	}, 100*time.Millisecond, 10*time.Millisecond, "state should be delivered exactly once")
+
+	cancel1()
+}
+
+// TestGetStateChan_ConcurrentDuplicateRegistrations verifies that the duplicate
+// check and the store are one atomic step: with N goroutines racing to subscribe
+// the same channel, exactly one must win.
+func TestGetStateChan_ConcurrentDuplicateRegistrations(t *testing.T) {
+	t.Parallel()
+
+	const racers = 8
+
+	manager := broadcast.NewManager(newTestLogger().Handler())
+	ch := make(chan string, racers)
+
+	var succeeded atomic.Int64
+	var wg sync.WaitGroup
+	for range racers {
+		wg.Go(func() {
+			if _, err := manager.GetStateChan(t.Context(), broadcast.WithCustomChannel(ch)); err == nil {
+				succeeded.Add(1)
+			}
+		})
+	}
+	wg.Wait()
+
+	assert.Equal(t, int64(1), succeeded.Load(), "exactly one concurrent registration should win")
+
+	// One subscription means one delivery.
+	manager.Broadcast("StateA")
+	require.Eventually(t, func() bool {
+		return len(ch) == 1
+	}, 100*time.Millisecond, 10*time.Millisecond, "expected exactly one delivery")
+}
+
+// TestGetStateChan_ResubscribeAfterCancelIsDeterministic verifies that a channel
+// whose subscription was just cancelled can be re-subscribed immediately, with
+// no wait for the teardown to finish. The take-over branch makes this
+// deterministic rather than a race between the new registration and the old
+// subscription's cleanup.
+func TestGetStateChan_ResubscribeAfterCancelIsDeterministic(t *testing.T) {
+	t.Parallel()
+
+	manager := broadcast.NewManager(newTestLogger().Handler())
+	ch := make(chan string, 10)
+
+	ctx1, cancel1 := context.WithCancel(t.Context())
+	_, err := manager.GetStateChan(ctx1, broadcast.WithCustomChannel(ch))
+	require.NoError(t, err)
+
+	cancel1()
+
+	// Deliberately no Eventually: this must succeed on the first attempt, even
+	// while the cancelled subscription's teardown is still in flight.
+	_, err = manager.GetStateChan(t.Context(), broadcast.WithCustomChannel(ch))
+	require.NoError(t, err, "re-subscribing after cancellation must be allowed immediately")
+
+	manager.Broadcast("StateA")
+	require.Eventually(t, func() bool {
+		select {
+		case state := <-ch:
+			return assert.Equal(t, "StateA", state)
+		default:
+			return false
+		}
+	}, 100*time.Millisecond, 10*time.Millisecond, "the new subscription should receive broadcasts")
+}
+
+// TestGetStateChan_CancelledContextRejected verifies that subscribing with an
+// already-cancelled context fails deterministically and leaves no phantom entry
+// behind.
+func TestGetStateChan_CancelledContextRejected(t *testing.T) {
+	t.Parallel()
+
+	manager := broadcast.NewManager(newTestLogger().Handler())
+	ch := make(chan string, 1)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	got, err := manager.GetStateChan(ctx, broadcast.WithCustomChannel(ch))
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Nil(t, got)
+
+	// No phantom subscription was registered: the channel subscribes cleanly,
+	// which a lingering live entry would reject as a duplicate.
+	_, err = manager.GetStateChan(t.Context(), broadcast.WithCustomChannel(ch))
+	require.NoError(t, err)
+}
+
+// TestGetStateChan_CancelRacingRegistration exercises a cancellation landing
+// during registration: the subscription must end up either rejected or fully
+// registered, never wedged in between.
+//
+// This is a smoke test for the interleaving, not a proof. The specific hazard --
+// context.AfterFunc firing its callback on a fresh goroutine when the context is
+// already done, completing teardown before the store publishes the subscription
+// and so stranding a departed entry in the map forever -- depends on a window
+// too narrow to hit on demand. GetStateChan closes it by construction, by arming
+// AfterFunc and storing under the same acquisition of the manager mutex.
+func TestGetStateChan_CancelRacingRegistration(t *testing.T) {
+	t.Parallel()
+
+	for range 200 {
+		manager := broadcast.NewManager(newTestLogger().Handler())
+		ch := make(chan string, 1)
+
+		ctx, cancel := context.WithCancel(context.Background())
+
+		var wg sync.WaitGroup
+		wg.Go(cancel)
+		wg.Go(func() {
+			// Either outcome is legal: rejected as cancelled, or registered and
+			// then torn down. Neither may leave a live-looking zombie behind.
+			//nolint:errcheck // both outcomes are valid; the assertion is below
+			_, _ = manager.GetStateChan(ctx, broadcast.WithCustomChannel(ch))
+		})
+		wg.Wait()
+
+		// Whatever happened, the channel must be usable again.
+		require.Eventually(t, func() bool {
+			_, err := manager.GetStateChan(t.Context(), broadcast.WithCustomChannel(ch))
+			return err == nil
+		}, 100*time.Millisecond, time.Millisecond, "channel should be re-subscribable after the racing cancel")
+
+		manager.UnsubscribeAll()
+	}
+}
+
+// TestUnsubscribeAll_RacingNewRegistration verifies that UnsubscribeAll and a
+// concurrent registration cannot corrupt each other. A subscription that
+// completes registration before the second pass takes the mutex is released;
+// one that lands after it survives. Either way the manager stays consistent.
+func TestUnsubscribeAll_RacingNewRegistration(t *testing.T) {
+	t.Parallel()
+
+	for range 100 {
+		manager := broadcast.NewManager(newTestLogger().Handler())
+		ch := make(chan string, 1)
+
+		_, err := manager.GetStateChan(context.Background(), broadcast.WithBufferSize(1))
+		require.NoError(t, err)
+
+		var wg sync.WaitGroup
+		wg.Go(manager.UnsubscribeAll)
+		wg.Go(func() {
+			//nolint:errcheck // either side may win the race; the assertion is below
+			_, _ = manager.GetStateChan(context.Background(), broadcast.WithCustomChannel(ch))
+		})
+		wg.Wait()
+
+		// Broadcasting must not panic regardless of which side won.
+		assert.NotPanics(t, func() { manager.Broadcast("StateA") })
+		manager.UnsubscribeAll()
 	}
 }

--- a/hooks/broadcast/options.go
+++ b/hooks/broadcast/options.go
@@ -21,16 +21,13 @@ import "time"
 // Option configures subscriber behavior.
 type Option func(*Config)
 
-// Config holds configuration for subscriber channels.
+// Config holds configuration for subscriber channels. It is purely the target
+// of the Option functions; Manager.GetStateChan copies what it needs into its
+// own per-subscriber record.
 type Config struct {
 	channel         chan string
 	externalChannel bool
 	timeout         time.Duration
-	// done is the subscriber's context cancellation signal, set by
-	// Manager.GetStateChan. Broadcast selects on it so a blocking send to a
-	// subscriber whose context has been cancelled is abandoned instead of
-	// holding the manager mutex forever.
-	done <-chan struct{}
 }
 
 // WithBufferSize creates a new internal channel with the specified buffer size.

--- a/hooks/config.go
+++ b/hooks/config.go
@@ -37,6 +37,14 @@ func (h HookType) String() string {
 }
 
 // PreTransitionHookConfig contains configuration for registering a pre-transition hook.
+//
+// From and To are copied at registration, so the caller may reuse or mutate the
+// slices once the register call has returned. They must not be mutated
+// concurrently with the registration call itself, since copying reads them.
+//
+// Duplicate entries in From or To are ignored for matching purposes: the hook
+// fires once per matching transition regardless. GetHooks still reports the
+// patterns exactly as registered.
 type PreTransitionHookConfig struct {
 	Name  string
 	From  []string
@@ -45,6 +53,14 @@ type PreTransitionHookConfig struct {
 }
 
 // PostTransitionHookConfig contains configuration for registering a post-transition hook.
+//
+// From and To are copied at registration, so the caller may reuse or mutate the
+// slices once the register call has returned. They must not be mutated
+// concurrently with the registration call itself, since copying reads them.
+//
+// Duplicate entries in From or To are ignored for matching purposes: the hook
+// fires once per matching transition regardless. GetHooks still reports the
+// patterns exactly as registered.
 type PostTransitionHookConfig struct {
 	Name   string
 	From   []string

--- a/hooks/errors.go
+++ b/hooks/errors.go
@@ -22,4 +22,16 @@ var (
 	// function (a nil Guard for a pre-transition hook or a nil Action for a
 	// post-transition hook).
 	ErrHookFuncNil = errors.New("hook function cannot be nil")
+
+	// ErrHookStatesEmpty is returned when registering a hook with an empty From
+	// or To state list
+	ErrHookStatesEmpty = errors.New("from and to state lists cannot be empty")
+
+	// ErrHookUnknownState is returned when a concrete state pattern is not
+	// present in the registry's transition table
+	ErrHookUnknownState = errors.New("unknown state")
+
+	// ErrHookWildcardUnsupported is returned when a wildcard pattern is used on
+	// a registry created without a transition table
+	ErrHookWildcardUnsupported = errors.New("wildcard '*' cannot be used without state table")
 )

--- a/hooks/registry.go
+++ b/hooks/registry.go
@@ -237,10 +237,14 @@ func (r *Registry) RegisterPreTransitionHook(config PreTransitionHookConfig) err
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
+	// Clone the caller's slices: hookEntry.matches reads them from the executors,
+	// which snapshot the index under RLock and release it before iterating, so a
+	// later caller-side mutation would silently change matching and a concurrent
+	// one would be a data race.
 	entry := &hookEntry{
 		guard:      config.Guard,
-		fromStates: config.From,
-		toStates:   config.To,
+		fromStates: slices.Clone(config.From),
+		toStates:   slices.Clone(config.To),
 		hookType:   HookTypePre,
 	}
 
@@ -254,10 +258,11 @@ func (r *Registry) RegisterPostTransitionHook(config PostTransitionHookConfig) e
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
+	// Clone the caller's slices; see RegisterPreTransitionHook for why.
 	entry := &hookEntry{
 		action:     config.Action,
-		fromStates: config.From,
-		toStates:   config.To,
+		fromStates: slices.Clone(config.From),
+		toStates:   slices.Clone(config.To),
 		hookType:   HookTypePost,
 	}
 
@@ -316,7 +321,7 @@ func (r *Registry) registerHookEntry(name string, entry *hookEntry) error {
 	}
 
 	if len(entry.fromStates) == 0 || len(entry.toStates) == 0 {
-		return fmt.Errorf("from and to state lists cannot be empty")
+		return ErrHookStatesEmpty
 	}
 
 	// Reject a missing callback at registration time rather than letting it
@@ -344,7 +349,7 @@ func (r *Registry) registerHookEntry(name string, entry *hookEntry) error {
 
 	if isWildcard {
 		if r.transitions == nil {
-			return fmt.Errorf("wildcard '*' cannot be used without state table (use WithTransitions option)")
+			return fmt.Errorf("%w (use WithTransitions option)", ErrHookWildcardUnsupported)
 		}
 	} else {
 		// For concrete patterns, validate states and build index keys
@@ -387,25 +392,18 @@ func (r *Registry) registerHookEntry(name string, entry *hookEntry) error {
 // Assumes no wildcards are present in the patterns (caller must check first).
 // Validates that all state names exist in the transition table if provided.
 func (r *Registry) buildConcreteIndexKeys(fromPatterns, toPatterns []string) ([]transitionKey, error) {
-	// Validate and collect from states
-	var fromStates []string
-	for _, pattern := range fromPatterns {
-		if r.transitions != nil && !r.transitions.HasState(pattern) {
-			return nil, fmt.Errorf("unknown state '%s'", pattern)
-		}
-		fromStates = append(fromStates, pattern)
+	fromStates, err := r.validateUniqueStates(fromPatterns)
+	if err != nil {
+		return nil, err
 	}
 
-	// Validate and collect to states
-	var toStates []string
-	for _, pattern := range toPatterns {
-		if r.transitions != nil && !r.transitions.HasState(pattern) {
-			return nil, fmt.Errorf("unknown state '%s'", pattern)
-		}
-		toStates = append(toStates, pattern)
+	toStates, err := r.validateUniqueStates(toPatterns)
+	if err != nil {
+		return nil, err
 	}
 
-	// Compute cartesian product
+	// Compute cartesian product. Both operands are duplicate-free, so every key
+	// is unique and the entry is indexed at most once per transition.
 	keys := make([]transitionKey, 0, len(fromStates)*len(toStates))
 	for _, from := range fromStates {
 		for _, to := range toStates {
@@ -414,6 +412,37 @@ func (r *Registry) buildConcreteIndexKeys(fromPatterns, toPatterns []string) ([]
 	}
 
 	return keys, nil
+}
+
+// validateUniqueStates validates each pattern against the transition table (when
+// one is configured) and returns the patterns with duplicates removed,
+// preserving first-occurrence order.
+//
+// De-duplication matters because these patterns feed a cartesian product used as
+// index keys. A repeated state produces a repeated key, which appends the same
+// hookEntry to one index slot more than once, and the guard or action then runs
+// once per duplicate for a single transition. Duplicates are dropped silently
+// rather than rejected: programmatically-assembled state lists commonly contain
+// them and the intended meaning is unambiguous.
+//
+// Validation runs before the duplicate check so a repeated unknown state still
+// reports the unknown-state error rather than being silently collapsed.
+func (r *Registry) validateUniqueStates(patterns []string) ([]string, error) {
+	seen := make(map[string]struct{}, len(patterns))
+	unique := make([]string, 0, len(patterns))
+
+	for _, pattern := range patterns {
+		if r.transitions != nil && !r.transitions.HasState(pattern) {
+			return nil, fmt.Errorf("%w '%s'", ErrHookUnknownState, pattern)
+		}
+		if _, dup := seen[pattern]; dup {
+			continue
+		}
+		seen[pattern] = struct{}{}
+		unique = append(unique, pattern)
+	}
+
+	return unique, nil
 }
 
 // safeCallGuard executes a guard with panic recovery.

--- a/hooks/registry_test.go
+++ b/hooks/registry_test.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"log/slog"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/robbyt/go-fsm/v2/transitions"
 	"github.com/stretchr/testify/assert"
@@ -391,6 +393,7 @@ func TestPatternExpansion(t *testing.T) {
 			},
 		})
 		require.Error(t, err)
+		require.ErrorIs(t, err, ErrHookUnknownState)
 		assert.Contains(t, err.Error(), "unknown state 'InvalidState'")
 	})
 
@@ -407,6 +410,7 @@ func TestPatternExpansion(t *testing.T) {
 			},
 		})
 		require.Error(t, err)
+		require.ErrorIs(t, err, ErrHookWildcardUnsupported)
 		assert.Contains(t, err.Error(), "wildcard '*' cannot be used without state table")
 	})
 
@@ -423,6 +427,7 @@ func TestPatternExpansion(t *testing.T) {
 			},
 		})
 		require.Error(t, err)
+		require.ErrorIs(t, err, ErrHookWildcardUnsupported)
 		assert.Contains(t, err.Error(), "wildcard '*' cannot be used without state table")
 	})
 
@@ -442,6 +447,7 @@ func TestPatternExpansion(t *testing.T) {
 			},
 		})
 		require.Error(t, err)
+		require.ErrorIs(t, err, ErrHookUnknownState)
 		assert.Contains(t, err.Error(), "unknown state 'InvalidState'")
 	})
 
@@ -908,6 +914,7 @@ func TestRegisterHookValidation(t *testing.T) {
 			},
 		})
 		require.Error(t, err)
+		require.ErrorIs(t, err, ErrHookStatesEmpty)
 		assert.Contains(t, err.Error(), "from and to state lists cannot be empty")
 	})
 
@@ -924,6 +931,7 @@ func TestRegisterHookValidation(t *testing.T) {
 			},
 		})
 		require.Error(t, err)
+		require.ErrorIs(t, err, ErrHookStatesEmpty)
 		assert.Contains(t, err.Error(), "from and to state lists cannot be empty")
 	})
 
@@ -939,6 +947,7 @@ func TestRegisterHookValidation(t *testing.T) {
 			},
 		})
 		require.Error(t, err)
+		require.ErrorIs(t, err, ErrHookStatesEmpty)
 		assert.Contains(t, err.Error(), "from and to state lists cannot be empty")
 	})
 
@@ -954,6 +963,7 @@ func TestRegisterHookValidation(t *testing.T) {
 			},
 		})
 		require.Error(t, err)
+		require.ErrorIs(t, err, ErrHookStatesEmpty)
 		assert.Contains(t, err.Error(), "from and to state lists cannot be empty")
 	})
 
@@ -969,6 +979,7 @@ func TestRegisterHookValidation(t *testing.T) {
 			},
 		})
 		require.Error(t, err)
+		require.ErrorIs(t, err, ErrHookWildcardUnsupported)
 		assert.Contains(t, err.Error(), "wildcard '*' cannot be used without state table")
 	})
 
@@ -1211,5 +1222,287 @@ func TestRegisterHook_NilFuncRejected(t *testing.T) {
 			Name: "ok-action", From: []string{"a"}, To: []string{"b"},
 			Action: func(ctx context.Context, from, to string) {},
 		}))
+	})
+}
+
+// TestRegisterHook_DuplicateStatesFireOnce verifies that duplicate entries in a
+// hook's From or To list do not index the same hookEntry more than once.
+// Before buildConcreteIndexKeys de-duplicated its patterns, the cartesian
+// product produced repeated transitionKeys, the entry was appended to one index
+// slot once per duplicate, and the guard or action ran once per duplicate for a
+// single transition.
+func TestRegisterHook_DuplicateStatesFireOnce(t *testing.T) {
+	t.Parallel()
+
+	trans := transitions.MustNew(map[string][]string{
+		"a": {"b", "c"},
+		"b": {},
+		"c": {},
+	})
+
+	t.Run("Duplicate from state fires a pre-transition hook once", func(t *testing.T) {
+		reg, err := NewRegistry(WithLogger(slog.Default()), WithTransitions(trans))
+		require.NoError(t, err)
+
+		calls := 0
+		require.NoError(t, reg.RegisterPreTransitionHook(PreTransitionHookConfig{
+			Name: "dup-from",
+			From: []string{"a", "a"},
+			To:   []string{"b"},
+			Guard: func(ctx context.Context, from, to string) error {
+				calls++
+				return nil
+			},
+		}))
+
+		require.NoError(t, reg.ExecutePreTransitionHooks(context.Background(), "a", "b"))
+		assert.Equal(t, 1, calls)
+	})
+
+	t.Run("Duplicate to state fires a post-transition hook once", func(t *testing.T) {
+		reg, err := NewRegistry(WithLogger(slog.Default()), WithTransitions(trans))
+		require.NoError(t, err)
+
+		calls := 0
+		require.NoError(t, reg.RegisterPostTransitionHook(PostTransitionHookConfig{
+			Name: "dup-to",
+			From: []string{"a"},
+			To:   []string{"b", "b"},
+			Action: func(ctx context.Context, from, to string) {
+				calls++
+			},
+		}))
+
+		reg.ExecutePostTransitionHooks(context.Background(), "a", "b")
+		assert.Equal(t, 1, calls)
+	})
+
+	t.Run("Duplicates in both lists fire once per matching transition", func(t *testing.T) {
+		reg, err := NewRegistry(WithLogger(slog.Default()), WithTransitions(trans))
+		require.NoError(t, err)
+
+		calls := make(map[string]int)
+		require.NoError(t, reg.RegisterPreTransitionHook(PreTransitionHookConfig{
+			Name: "dup-both",
+			From: []string{"a", "a"},
+			To:   []string{"b", "b", "c"},
+			Guard: func(ctx context.Context, from, to string) error {
+				calls[from+"->"+to]++
+				return nil
+			},
+		}))
+
+		require.NoError(t, reg.ExecutePreTransitionHooks(context.Background(), "a", "b"))
+		require.NoError(t, reg.ExecutePreTransitionHooks(context.Background(), "a", "c"))
+		assert.Equal(t, map[string]int{"a->b": 1, "a->c": 1}, calls)
+	})
+
+	t.Run("Distinct states still expand to the full cartesian product", func(t *testing.T) {
+		reg, err := NewRegistry(WithLogger(slog.Default()), WithTransitions(trans))
+		require.NoError(t, err)
+
+		calls := make(map[string]int)
+		require.NoError(t, reg.RegisterPreTransitionHook(PreTransitionHookConfig{
+			Name: "distinct",
+			From: []string{"a"},
+			To:   []string{"b", "c"},
+			Guard: func(ctx context.Context, from, to string) error {
+				calls[from+"->"+to]++
+				return nil
+			},
+		}))
+
+		require.NoError(t, reg.ExecutePreTransitionHooks(context.Background(), "a", "b"))
+		require.NoError(t, reg.ExecutePreTransitionHooks(context.Background(), "a", "c"))
+		assert.Equal(t, map[string]int{"a->b": 1, "a->c": 1}, calls)
+	})
+
+	t.Run("GetHooks reports the caller's patterns verbatim", func(t *testing.T) {
+		reg, err := NewRegistry(WithLogger(slog.Default()), WithTransitions(trans))
+		require.NoError(t, err)
+
+		require.NoError(t, reg.RegisterPreTransitionHook(PreTransitionHookConfig{
+			Name: "verbatim",
+			From: []string{"a", "a"},
+			To:   []string{"b", "b"},
+			Guard: func(ctx context.Context, from, to string) error {
+				return nil
+			},
+		}))
+
+		hooks := reg.GetHooks()
+		require.Len(t, hooks, 1)
+		// De-duplication is confined to index construction; the reported
+		// metadata is whatever the caller registered.
+		assert.Equal(t, []string{"a", "a"}, hooks[0].FromStates)
+		assert.Equal(t, []string{"b", "b"}, hooks[0].ToStates)
+	})
+
+	t.Run("Wildcard hook with duplicate states fires once", func(t *testing.T) {
+		reg, err := NewRegistry(WithLogger(slog.Default()), WithTransitions(trans))
+		require.NoError(t, err)
+
+		calls := 0
+		require.NoError(t, reg.RegisterPreTransitionHook(PreTransitionHookConfig{
+			Name: "dup-wildcard",
+			From: []string{"*", "*"},
+			To:   []string{"b", "b"},
+			Guard: func(ctx context.Context, from, to string) error {
+				calls++
+				return nil
+			},
+		}))
+
+		require.NoError(t, reg.ExecutePreTransitionHooks(context.Background(), "a", "b"))
+		assert.Equal(t, 1, calls)
+	})
+
+	t.Run("Repeated unknown state still reports the unknown state", func(t *testing.T) {
+		reg, err := NewRegistry(WithLogger(slog.Default()), WithTransitions(trans))
+		require.NoError(t, err)
+
+		err = reg.RegisterPreTransitionHook(PreTransitionHookConfig{
+			Name: "dup-unknown",
+			From: []string{"zzz", "zzz"},
+			To:   []string{"b"},
+			Guard: func(ctx context.Context, from, to string) error {
+				return nil
+			},
+		})
+		require.ErrorIs(t, err, ErrHookUnknownState)
+		assert.Contains(t, err.Error(), "unknown state 'zzz'")
+	})
+}
+
+// TestRegisterHook_ConfigSlicesAreCopied verifies that registration does not
+// alias the caller's From/To slices. Before the register methods cloned them,
+// mutating the caller's slice silently changed matching (a wildcard hook could
+// be disabled outright), and mutating it concurrently with a transition was a
+// data race: hookEntry.matches reads those slices from the executors, which
+// snapshot the index under RLock and then release it before iterating.
+func TestRegisterHook_ConfigSlicesAreCopied(t *testing.T) {
+	t.Parallel()
+
+	trans := transitions.MustNew(map[string][]string{"a": {"b"}, "b": {}})
+
+	t.Run("Mutating From after registration does not change matching", func(t *testing.T) {
+		reg, err := NewRegistry(WithLogger(slog.Default()), WithTransitions(trans))
+		require.NoError(t, err)
+
+		from := []string{"a"}
+		calls := 0
+		require.NoError(t, reg.RegisterPreTransitionHook(PreTransitionHookConfig{
+			Name: "mut-from",
+			From: from,
+			To:   []string{"*"}, // wildcard forces runtime matching via hookEntry.matches
+			Guard: func(ctx context.Context, f, to string) error {
+				calls++
+				return nil
+			},
+		}))
+
+		from[0] = "zzz" // caller mutates their own slice after registration
+
+		require.NoError(t, reg.ExecutePreTransitionHooks(context.Background(), "a", "b"))
+		assert.Equal(t, 1, calls, "hook must still match the state it was registered with")
+	})
+
+	t.Run("Mutating To after registration does not change matching", func(t *testing.T) {
+		reg, err := NewRegistry(WithLogger(slog.Default()), WithTransitions(trans))
+		require.NoError(t, err)
+
+		to := []string{"b"}
+		calls := 0
+		require.NoError(t, reg.RegisterPostTransitionHook(PostTransitionHookConfig{
+			Name: "mut-to",
+			From: []string{"*"},
+			To:   to,
+			Action: func(ctx context.Context, f, t2 string) {
+				calls++
+			},
+		}))
+
+		to[0] = "zzz"
+
+		reg.ExecutePostTransitionHooks(context.Background(), "a", "b")
+		assert.Equal(t, 1, calls, "hook must still match the state it was registered with")
+	})
+
+	t.Run("Mutation is not visible through GetHooks", func(t *testing.T) {
+		reg, err := NewRegistry(WithLogger(slog.Default()), WithTransitions(trans))
+		require.NoError(t, err)
+
+		from := []string{"a"}
+		to := []string{"b"}
+		calls := 0
+		require.NoError(t, reg.RegisterPreTransitionHook(PreTransitionHookConfig{
+			Name: "mut-both",
+			From: from,
+			To:   to,
+			Guard: func(ctx context.Context, f, t2 string) error {
+				calls++
+				return nil
+			},
+		}))
+
+		from[0] = "zzz"
+		to[0] = "zzz"
+
+		hooks := reg.GetHooks()
+		require.Len(t, hooks, 1)
+		assert.Equal(t, []string{"a"}, hooks[0].FromStates)
+		assert.Equal(t, []string{"b"}, hooks[0].ToStates)
+
+		// The concrete index key was built from the original values too.
+		require.NoError(t, reg.ExecutePreTransitionHooks(context.Background(), "a", "b"))
+		assert.Equal(t, 1, calls)
+	})
+
+	t.Run("Concurrent mutation and execution is race-free", func(t *testing.T) {
+		reg, err := NewRegistry(WithLogger(slog.Default()), WithTransitions(trans))
+		require.NoError(t, err)
+
+		from := []string{"a"}
+		var executions atomic.Int64
+		require.NoError(t, reg.RegisterPreTransitionHook(PreTransitionHookConfig{
+			Name: "racy",
+			From: from,
+			To:   []string{"*"}, // wildcard: matches runs on every execution
+			Guard: func(ctx context.Context, f, to string) error {
+				executions.Add(1)
+				return nil
+			},
+		}))
+
+		stop := make(chan struct{})
+		var wg sync.WaitGroup
+		wg.Go(func() {
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					if err := reg.ExecutePreTransitionHooks(context.Background(), "a", "b"); err != nil {
+						t.Errorf("unexpected hook error: %v", err)
+						return
+					}
+				}
+			}
+		})
+		// Always stop and join the executor goroutine, even if the loop below
+		// fails early, so it cannot outlive the test.
+		t.Cleanup(func() {
+			close(stop)
+			wg.Wait()
+		})
+
+		// Mutate the caller's slice while the executor reads the registry's copy.
+		// Wait for real overlap rather than assuming the goroutine got scheduled:
+		// without executions the race detector would have nothing to observe.
+		require.Eventually(t, func() bool {
+			from[0] = "zzz"
+			from[0] = "a"
+			return executions.Load() > 100
+		}, 500*time.Millisecond, time.Millisecond, "executor goroutine never overlapped with the mutations")
 	})
 }

--- a/readme_test.go
+++ b/readme_test.go
@@ -361,6 +361,42 @@ func TestReadme_SubscribingToStateChanges(t *testing.T) {
 	})
 }
 
+// TestReadme_EndingASubscription tests the "Ending a Subscription" example from
+// README.md: cancelling the context ends the subscription, and Close releases a
+// machine that shares a registry.
+func TestReadme_EndingASubscription(t *testing.T) {
+	t.Parallel()
+
+	sharedRegistry, err := hooks.NewRegistry(
+		hooks.WithLogHandler(slog.Default().Handler()),
+		hooks.WithTransitions(transitions.Typical),
+	)
+	require.NoError(t, err)
+
+	machine, err := New(
+		transitions.StatusNew,
+		transitions.Typical,
+		WithCallbackRegistry(sharedRegistry),
+	)
+	require.NoError(t, err)
+	defer func() {
+		// README: defer machine.Close()
+		require.NoError(t, machine.Close())
+	}()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	stateChan := make(chan string, 10)
+	mustSubscribe(t, machine, ctx, stateChan)
+	assert.Equal(t, transitions.StatusNew, <-stateChan)
+
+	// README: cancelling the context ends the subscription.
+	cancel()
+
+	// The machine keeps working afterwards.
+	require.NoError(t, machine.Transition(transitions.StatusBooting))
+	assert.Equal(t, transitions.StatusBooting, machine.GetState())
+}
+
 // TestReadme_StateTransitionOperations tests state transition examples from README.md
 func TestReadme_StateTransitionOperations(t *testing.T) {
 	t.Parallel()

--- a/transitions/config.go
+++ b/transitions/config.go
@@ -158,6 +158,17 @@ func (t *Config) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements json.Unmarshaler interface.
 // It deserializes the config map and rebuilds the internal index.
+//
+// This is the one operation that mutates a Config in place, so it must only be
+// called on a Config that has not yet been shared: not attached to an fsm.Machine
+// and not reachable from another goroutine. Every other method treats a Config as
+// immutable after construction, and fsm.Machine relies on that to read its
+// transition table without holding a lock (see the transitionDB contract in
+// fsm.go). Unmarshaling into a Config that is already in use is a data race and
+// can swap the transition table under a running machine non-atomically.
+//
+// To load transitions into a machine that already exists, unmarshal into a fresh
+// Config and build a new Machine from it.
 func (t *Config) UnmarshalJSON(data []byte) error {
 	var config map[string][]string
 	if err := json.Unmarshal(data, &config); err != nil {


### PR DESCRIPTION
> [!IMPORTANT]
> **Superseded — do not merge.** This PR has been split into stack #89 (#81 – #88) for reviewability.
> Closing this unmerged; the replacement PRs carry all of its content.

The original PR bundled one High and six Medium fixes plus a rename into ~2,000 lines across 19 files in 4 commits, split by *package* rather than by *concern* — a reviewer could not tell which lines fixed which bug.

## Replacement stack (#89)

| PR | What it fixes |
|---|---|
| #81 | rename `GetStateChan` → `Subscribe`, deprecated alias kept |
| #82 | hooks: duplicate states fire once; caller slices copied; error sentinels |
| #83 | broadcast: extract subscription record (behavior-neutral refactor) |
| #84 | broadcast: per-subscription cleanup goroutine leak |
| #85 | broadcast: duplicate channel subscriptions corrupt tracking |
| #86 | fsm: nil state channel wedges the machine (the High-severity bug) |
| #87 | fsm: `%p` hook names collide after GC; failed setup cached forever |
| #88 | fsm: `Machine.Close` releases a shared registry's broadcast hook |

## Equivalence

The eight PRs are byte-identical to this branch **plus three defects found while splitting**:

1. `docs/v2-upgrade.md` documented an error string the rename had changed (→ #81).
2. `Broadcast`'s `timeout > 0` branch never selected on departure, so `UnsubscribeAll` could not release a parked timeout-mode send and `Machine.Close` blocked for the full timeout (→ #84).
3. `TestSubscribe_InitialSendRespectsContext` had become a tautology — it passed for the wrong reason (→ #86).

Verified by tree-hash comparison: the tip of #88 and the corrected baseline are the same tree object.

https://claude.ai/code/session_01WMFFnBa2iXgQ8ZqMjfYREP