### PR TITLE
refactor: rename Machine.GetStateChan to Subscribe, keeping a deprecated alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ Subscribe to state change notifications using channels. This is useful for updat
 
 #### Simple Method (Recommended)
 
-Use the built-in `GetStateChan()` method for state notifications:
+Use the built-in `Subscribe()` method for state notifications:
 
 ```go
 import (
@@ -401,7 +401,7 @@ defer cancel()
 
 // Register a buffered channel; the current state is sent immediately.
 stateChan := make(chan string, 10)
-_ = machine.GetStateChan(ctx, stateChan)
+_ = machine.Subscribe(ctx, stateChan)
 
 go func() {
 	for {
@@ -418,7 +418,7 @@ go func() {
 _ = machine.Transition(transitions.StatusBooting)
 ```
 
-The `GetStateChan()` method:
+The `Subscribe()` method:
 - Automatically sets up broadcast management
 - Sends the current state immediately upon subscription
 - Unsubscribes the channel when the context is cancelled

--- a/callbacks.go
+++ b/callbacks.go
@@ -39,7 +39,7 @@ type CallbackExecutor interface {
 }
 
 // HookRegistrar extends CallbackExecutor with dynamic hook registration.
-// This interface is used by GetStateChan to register broadcast hooks dynamically.
+// This interface is used by Subscribe to register broadcast hooks dynamically.
 // The hooks.Registry type implements this interface.
 type HookRegistrar interface {
 	RegisterPostTransitionHook(config hooks.PostTransitionHookConfig) error

--- a/docs/v2-upgrade.md
+++ b/docs/v2-upgrade.md
@@ -11,7 +11,7 @@ This guide walks through migrating a Go codebase from `github.com/robbyt/go-fsm`
 | **Logger Setup** | Required as first parameter to `New` constructor | Optional via `fsm.WithLogHandler(handler)` |
 | **State Constants** | `fsm.StatusNew`, `fsm.StatusBooting`, etc. | `transitions.StatusNew`, `transitions.StatusBooting`, etc. |
 | **Transitions Type** | `map[string][]string` (also `fsm.TypicalTransitions`) | `*transitions.Config` (use `transitions.Typical` for common transitions) |
-| **State Broadcasting** | `stateChan := machine.GetStateChan(ctx)` | `err := machine.GetStateChan(ctx, chan)` with a user-created channel |
+| **State Broadcasting** | `stateChan := machine.GetStateChan(ctx)` | `err := machine.Subscribe(ctx, chan)` with a user-created channel |
 | **Broadcast Timeout** | `fsm.WithSyncTimeout(duration)` | `fsm.WithBroadcastTimeout(duration)` option |
 | **Hooks/Callbacks** | Not supported | New `hooks.Registry` with pre/post hooks |
 
@@ -19,7 +19,7 @@ This guide walks through migrating a Go codebase from `github.com/robbyt/go-fsm`
 
 **Key Feature:** v2 provides a **built-in helper method** for state broadcasting that's simpler than manual setup:
 
-- ✅ **One Method Call**: `machine.GetStateChan(ctx, chan)` handles everything
+- ✅ **One Method Call**: `machine.Subscribe(ctx, chan)` handles everything
 - ✅ **Automatic Hook Registration**: Broadcast hook registered automatically on first call
 - ✅ **v1 Compatible**: Sends initial state immediately (just like v1)
 - ✅ **You Control the Channel**: Create buffered or unbuffered channels as needed
@@ -91,7 +91,7 @@ import (
     "github.com/robbyt/go-fsm/v2"
     "github.com/robbyt/go-fsm/v2/transitions"
     "github.com/robbyt/go-fsm/v2/hooks"           // if using callbacks
-    "github.com/robbyt/go-fsm/v2/hooks/broadcast" // if using GetStateChan
+    "github.com/robbyt/go-fsm/v2/hooks/broadcast" // if using Subscribe
 )
 ```
 
@@ -179,7 +179,7 @@ Do you need state change notifications?
 └─ YES → Choose your approach:
     │
     ├─ SIMPLE (Recommended for 90% of use cases)
-    │  ✅ Use: machine.GetStateChan(ctx, chan)
+    │  ✅ Use: machine.Subscribe(ctx, chan)
     │  ✅ When: Standard broadcasting, single FSM, v1 compatibility
     │  ✅ Benefits: Automatic setup, simpler code, less boilerplate
     │
@@ -228,8 +228,8 @@ machine, err := fsm.New(
 // 3. Create your channel (you control buffer size)
 stateChan := make(chan string, 10)
 
-// 4. Register the channel with GetStateChan
-err = machine.GetStateChan(ctx, stateChan)
+// 4. Register the channel with Subscribe
+err = machine.Subscribe(ctx, stateChan)
 if err != nil {
     // Handle error
 }
@@ -287,7 +287,7 @@ for state := range stateChan {
 
 1. **Channel Creation**: You create and own the channel (control buffer size)
 2. **Registry Required**: Must use `hooks.Registry` with `WithTransitions()`
-3. **v1 Compatible**: `machine.GetStateChan()` sends initial state immediately (like v1)
+3. **v1 Compatible**: `machine.Subscribe()` sends initial state immediately (like v1)
 4. **Configurable Timeout**: Use `WithBroadcastTimeout()` option (replaces v1's `WithSyncTimeout`)
 5. **Error Handling**: Returns error instead of just returning a channel
 
@@ -344,13 +344,13 @@ type Machine struct {
 func (m *Machine) GetStateChan(ctx context.Context) <-chan string {
     ch := make(chan string, 10)
 
-    err := m.Machine.GetStateChan(ctx, ch)
+    err := m.Machine.Subscribe(ctx, ch)
     if err != nil {
         close(ch)
         return ch
     }
 
-    // machine.GetStateChan already sends current state immediately (v1 compatible!)
+    // machine.Subscribe already sends current state immediately (v1 compatible!)
     return ch
 }
 
@@ -497,7 +497,7 @@ machine, err := fsm.New(
 machine, err := fsm.New(handler, fsm.StatusNew, fsm.TypicalTransitions)
 stateChan := machine.GetStateChan(ctx)
 
-// v2 - using built-in GetStateChan helper
+// v2 - using built-in Subscribe helper
 registry, err := hooks.NewRegistry(
     hooks.WithLogHandler(handler),
     hooks.WithTransitions(transitions.Typical),
@@ -511,7 +511,7 @@ machine, err := fsm.New(
 )
 
 stateChan := make(chan string, 10)
-err = machine.GetStateChan(ctx, stateChan)
+err = machine.Subscribe(ctx, stateChan)
 
 // Use the channel
 for state := range stateChan {
@@ -545,11 +545,11 @@ machine, err := fsm.New("draft", customTrans)
 ### Error: "cannot use map[string][]string as type transitionDB"
 **Solution:** Wrap map with `transitions.MustNew(yourMap)` or use `transitions.New(yourMap)`
 
-### Error: "GetStateChan requires a callback registry"
+### Error: "Subscribe requires a callback registry"
 **Solution:** Use `fsm.WithCallbackRegistry(registry)` when creating the FSM. The registry must be created with `hooks.WithTransitions()` for wildcard support.
 
 ### Error: "requires a callback registry that supports dynamic hook registration"
-**Solution:** Use `hooks.Registry` instead of a custom CallbackExecutor. The FSM's built-in `GetStateChan` requires the registry to support dynamic hook registration.
+**Solution:** Use `hooks.Registry` instead of a custom CallbackExecutor. The FSM's built-in `Subscribe` requires the registry to support dynamic hook registration.
 
 ### Error: "wildcard '*' cannot be used without state table"
 **Solution:** When using wildcard hooks (`"*"`), you must pass `hooks.WithTransitions()` to the registry.
@@ -569,7 +569,7 @@ Use this checklist to verify your migration:
 - [ ] Replaced `fsm.StatusX` with `transitions.StatusX`
 - [ ] Replaced `fsm.TypicalTransitions` with `transitions.Typical`
 - [ ] Updated `fsm.New()` constructor calls (moved handler to options)
-- [ ] Migrated `GetStateChan()` to use `machine.GetStateChan(ctx, chan)` with hooks.Registry
+- [ ] Migrated `GetStateChan()` to `machine.Subscribe(ctx, chan)` with hooks.Registry
 - [ ] Added `WithBroadcastTimeout()` option if custom timeout needed (replaces `WithSyncTimeout`)
 - [ ] **Created single abstraction constructor (if architecture supports it)**
 - [ ] Updated all tests

--- a/example/main.go
+++ b/example/main.go
@@ -54,7 +54,7 @@ func run(ctx context.Context, logger *slog.Logger, output io.Writer) (*fsm.Machi
 
 	// Create a channel to receive state change broadcasts
 	stateChan := make(chan string, 10)
-	err = machine.GetStateChan(ctx, stateChan)
+	err = machine.Subscribe(ctx, stateChan)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get state channel: %w", err)
 	}

--- a/fsm.go
+++ b/fsm.go
@@ -353,15 +353,15 @@ func (fsm *Machine) transition(ctx context.Context, toState string) error {
 	return nil
 }
 
-// GetStateChan registers a channel to receive state change notifications and sends
+// Subscribe registers a channel to receive state change notifications and sends
 // the current state immediately, blocking on sending the initial state if the channel buffer is full.
 // Use a buffered channel to avoid blocking.
 //
 // Subscriber registration and the initial-state send happen while holding the FSM read lock, so they
-// are atomic with respect to transitions. Two consequences follow: GetStateChan must NOT be called
+// are atomic with respect to transitions. Two consequences follow: Subscribe must NOT be called
 // from within a transition hook (the hook already holds the FSM write lock, so this would deadlock),
 // and a full or unbuffered channel blocks transitions until the initial send drains. The initial
-// send honors the provided context — if ctx is cancelled while it is blocked, GetStateChan returns
+// send honors the provided context — if ctx is cancelled while it is blocked, Subscribe returns
 // the context's error.
 //
 // This method requires the FSM to be configured with a hooks.Registry (via WithCallbackRegistry).
@@ -372,11 +372,11 @@ func (fsm *Machine) transition(ctx context.Context, toState string) error {
 // is cancelled, at which point it is automatically unsubscribed from receiving further broadcasts.
 // The channel is NOT closed; the caller maintains ownership and is responsible for channel lifecycle.
 //
-// GetStateChan can be called multiple times with different channels and contexts. All channels
+// Subscribe can be called multiple times with different channels and contexts. All channels
 // share the same broadcast manager, which is lazily initialized only once upon the first call.
 //
 // Each Machine registers its broadcast hook under a name unique to that Machine, so a single
-// hooks.Registry may be shared across Machines without GetStateChan failing. Note, however, that
+// hooks.Registry may be shared across Machines without Subscribe failing. Note, however, that
 // hooks registered on a shared registry fire for every Machine's transitions; prefer one registry
 // per Machine unless that shared behavior is intended.
 //
@@ -408,7 +408,7 @@ func (fsm *Machine) transition(ctx context.Context, toState string) error {
 //	defer cancel()
 //
 //	stateChan := make(chan string, 10)
-//	if err := machine.GetStateChan(ctx, stateChan); err != nil {
+//	if err := machine.Subscribe(ctx, stateChan); err != nil {
 //	    return err
 //	}
 //
@@ -422,18 +422,18 @@ func (fsm *Machine) transition(ctx context.Context, toState string) error {
 //	        }
 //	    }
 //	}()
-func (fsm *Machine) GetStateChan(ctx context.Context, c chan string) error {
+func (fsm *Machine) Subscribe(ctx context.Context, c chan string) error {
 	if ctx == nil {
 		return fmt.Errorf("context cannot be nil")
 	}
 
 	if fsm.callbacks == nil {
-		return fmt.Errorf("GetStateChan requires a callback registry")
+		return fmt.Errorf("Subscribe requires a callback registry")
 	}
 
 	registrar, ok := fsm.callbacks.(HookRegistrar)
 	if !ok {
-		return fmt.Errorf("GetStateChan requires a callback registry that supports dynamic hook registration")
+		return fmt.Errorf("Subscribe requires a callback registry that supports dynamic hook registration")
 	}
 
 	fsm.stateChanSetup.Do(func() {
@@ -442,9 +442,9 @@ func (fsm *Machine) GetStateChan(ctx context.Context, c chan string) error {
 		// Use a per-machine hook name so multiple machines can share one
 		// registry. A constant name would collide on the second machine
 		// (ErrHookNameAlreadyExists), and because the error is cached in the
-		// sync.Once that machine's GetStateChan would then fail permanently.
+		// sync.Once that machine's Subscribe would then fail permanently.
 		fsm.stateChanSetupErr = registrar.RegisterPostTransitionHook(hooks.PostTransitionHookConfig{
-			Name:   fmt.Sprintf("fsm.GetStateChan.%p", fsm),
+			Name:   fmt.Sprintf("fsm.Subscribe.%p", fsm),
 			From:   []string{"*"},
 			To:     []string{"*"},
 			Action: fsm.broadcastManager.BroadcastHook,
@@ -460,7 +460,7 @@ func (fsm *Machine) GetStateChan(ctx context.Context, c chan string) error {
 	// hook runs inside transition()), so the read lock guarantees no transition
 	// can broadcast between registering the channel and sending the initial
 	// state. Without it, a concurrent transition could make the subscriber
-	// observe a duplicated or out-of-order first value. Concurrent GetStateChan
+	// observe a duplicated or out-of-order first value. Concurrent Subscribe
 	// callers still proceed in parallel under the shared read lock. (See the
 	// method doc for the blocking and hook-reentrancy implications.)
 	fsm.mutex.RLock()
@@ -486,4 +486,13 @@ func (fsm *Machine) GetStateChan(ctx context.Context, c chan string) error {
 	}
 
 	return nil
+}
+
+// GetStateChan registers a channel to receive state change notifications.
+//
+// Deprecated: GetStateChan is the pre-v2.6 name of this method and is retained
+// for compatibility. Use [Machine.Subscribe], which has the same signature and
+// behaviour.
+func (fsm *Machine) GetStateChan(ctx context.Context, c chan string) error {
+	return fsm.Subscribe(ctx, c)
 }

--- a/fsm_test.go
+++ b/fsm_test.go
@@ -658,7 +658,7 @@ func TestFSM_TransitionWithContext(t *testing.T) {
 	})
 }
 
-func TestFSM_GetStateChan(t *testing.T) {
+func TestFSM_Subscribe(t *testing.T) {
 	t.Parallel()
 
 	t.Run("Error: nil context", func(t *testing.T) {
@@ -671,7 +671,7 @@ func TestFSM_GetStateChan(t *testing.T) {
 
 		c := make(chan string, 1)
 		//nolint:staticcheck // Intentionally testing nil context error
-		err = fsm.GetStateChan(nil, c)
+		err = fsm.Subscribe(nil, c)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "context cannot be nil")
 	})
@@ -686,9 +686,9 @@ func TestFSM_GetStateChan(t *testing.T) {
 
 		ctx := context.Background()
 		c := make(chan string, 1)
-		err = fsm.GetStateChan(ctx, c)
+		err = fsm.Subscribe(ctx, c)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "GetStateChan requires a callback registry")
+		assert.Contains(t, err.Error(), "Subscribe requires a callback registry")
 	})
 
 	t.Run("Error: callbacks not HookRegistrar", func(t *testing.T) {
@@ -702,7 +702,7 @@ func TestFSM_GetStateChan(t *testing.T) {
 
 		ctx := context.Background()
 		c := make(chan string, 1)
-		err = fsm.GetStateChan(ctx, c)
+		err = fsm.Subscribe(ctx, c)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "requires a callback registry that supports dynamic hook registration")
 	})
@@ -721,7 +721,7 @@ func TestFSM_GetStateChan(t *testing.T) {
 
 		ctx := context.Background()
 		c := make(chan string, 1)
-		err = fsm.GetStateChan(ctx, c)
+		err = fsm.Subscribe(ctx, c)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "wildcard")
 	})
@@ -748,7 +748,7 @@ func TestFSM_GetStateChan(t *testing.T) {
 		ctx := t.Context()
 
 		c := make(chan string, 10)
-		err = fsm.GetStateChan(ctx, c)
+		err = fsm.Subscribe(ctx, c)
 		require.NoError(t, err)
 
 		// Should receive initial state immediately
@@ -791,12 +791,12 @@ func TestFSM_GetStateChan(t *testing.T) {
 
 		// Register first channel
 		c1 := make(chan string, 10)
-		err = fsm.GetStateChan(ctx, c1)
+		err = fsm.Subscribe(ctx, c1)
 		require.NoError(t, err)
 
 		// Register second channel
 		c2 := make(chan string, 10)
-		err = fsm.GetStateChan(ctx, c2)
+		err = fsm.Subscribe(ctx, c2)
 		require.NoError(t, err)
 
 		// Both should receive initial state
@@ -836,7 +836,7 @@ func TestFSM_GetStateChan(t *testing.T) {
 		ctx := t.Context()
 
 		c := make(chan string, 10)
-		err = fsm.GetStateChan(ctx, c)
+		err = fsm.Subscribe(ctx, c)
 		require.NoError(t, err)
 
 		// Should work normally with custom timeout
@@ -870,7 +870,7 @@ func TestFSM_GetStateChan(t *testing.T) {
 			defer cancel()
 
 			c := make(chan string, 10)
-			err = fsm.GetStateChan(ctx, c)
+			err = fsm.Subscribe(ctx, c)
 			require.NoError(t, err)
 
 			// Receive states using select to avoid goroutine leak
@@ -896,13 +896,13 @@ func TestFSM_GetStateChan(t *testing.T) {
 	})
 }
 
-// TestGetStateChan_SharedRegistry verifies that two machines can share a single
-// hooks.Registry. Previously GetStateChan registered its broadcast hook under a
+// TestSubscribe_SharedRegistry verifies that two machines can share a single
+// hooks.Registry. Previously Subscribe registered its broadcast hook under a
 // constant name, so the second machine's registration failed with
 // ErrHookNameAlreadyExists and, because the error is cached in sync.Once, that
-// machine's GetStateChan failed permanently. With a per-machine hook name both
+// machine's Subscribe failed permanently. With a per-machine hook name both
 // machines can subscribe.
-func TestGetStateChan_SharedRegistry(t *testing.T) {
+func TestSubscribe_SharedRegistry(t *testing.T) {
 	t.Parallel()
 
 	reg, err := hooks.NewRegistry(hooks.WithTransitions(transitions.Typical))
@@ -918,23 +918,23 @@ func TestGetStateChan_SharedRegistry(t *testing.T) {
 
 	ch1 := make(chan string, 10)
 	ch2 := make(chan string, 10)
-	require.NoError(t, m1.GetStateChan(ctx, ch1))
-	require.NoError(t, m2.GetStateChan(ctx, ch2)) // previously failed permanently
+	require.NoError(t, m1.Subscribe(ctx, ch1))
+	require.NoError(t, m2.Subscribe(ctx, ch2)) // previously failed permanently
 
 	// Each subscriber receives its own machine's initial state.
 	assert.Equal(t, transitions.StatusNew, <-ch1)
 	assert.Equal(t, transitions.StatusNew, <-ch2)
 }
 
-// TestGetStateChan_InitialSendIsAtomic verifies that registering a subscriber
+// TestSubscribe_InitialSendIsAtomic verifies that registering a subscriber
 // and sending its initial state happen atomically with respect to transitions.
-// Before GetStateChan held the read lock across registration and the initial
+// Before Subscribe held the read lock across registration and the initial
 // send, a concurrent transition could broadcast between the two steps, so the
 // subscriber observed a duplicated or stale first value. With strictly
 // alternating Running<->Reloading transitions, the initial value (current
 // state) and the first broadcast that follows must always differ; an equal
 // pair signals the race.
-func TestGetStateChan_InitialSendIsAtomic(t *testing.T) {
+func TestSubscribe_InitialSendIsAtomic(t *testing.T) {
 	reg, err := hooks.NewRegistry(hooks.WithTransitions(transitions.Typical))
 	require.NoError(t, err)
 	machine, err := New(transitions.StatusRunning, transitions.Typical,
@@ -966,7 +966,7 @@ func TestGetStateChan_InitialSendIsAtomic(t *testing.T) {
 	for i := range 500 {
 		ctx, cancel := context.WithCancel(context.Background())
 		ch := make(chan string, 256)
-		require.NoError(t, machine.GetStateChan(ctx, ch))
+		require.NoError(t, machine.Subscribe(ctx, ch))
 
 		// Collect the initial value plus the first broadcast.
 		var got []string
@@ -987,11 +987,11 @@ func TestGetStateChan_InitialSendIsAtomic(t *testing.T) {
 	}
 }
 
-// TestGetStateChan_InitialSendRespectsContext verifies that the initial-state
+// TestSubscribe_InitialSendRespectsContext verifies that the initial-state
 // send honors the context: with an unbuffered channel and no reader the send
-// blocks, and a cancelled context makes GetStateChan return the context error
+// blocks, and a cancelled context makes Subscribe return the context error
 // instead of hanging while holding the FSM read lock.
-func TestGetStateChan_InitialSendRespectsContext(t *testing.T) {
+func TestSubscribe_InitialSendRespectsContext(t *testing.T) {
 	t.Parallel()
 
 	reg, err := hooks.NewRegistry(hooks.WithTransitions(transitions.Typical))
@@ -1003,9 +1003,35 @@ func TestGetStateChan_InitialSendRespectsContext(t *testing.T) {
 	cancel() // cancel up front so the blocked initial send aborts
 
 	ch := make(chan string) // unbuffered, no reader: the initial send blocks
-	err = machine.GetStateChan(ctx, ch)
+	err = machine.Subscribe(ctx, ch)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, context.Canceled)
+}
+
+// TestGetStateChan_DeprecatedAliasDelegatesToSubscribe verifies that the
+// deprecated wrapper still works and behaves identically to Subscribe, so
+// callers on the old name keep working.
+func TestGetStateChan_DeprecatedAliasDelegatesToSubscribe(t *testing.T) {
+	t.Parallel()
+
+	reg, err := hooks.NewRegistry(hooks.WithTransitions(transitions.Typical))
+	require.NoError(t, err)
+	machine, err := New(transitions.StatusNew, transitions.Typical, WithCallbackRegistry(reg))
+	require.NoError(t, err)
+
+	ch := make(chan string, 10)
+	require.NoError(t, machine.GetStateChan(t.Context(), ch))
+	assert.Equal(t, transitions.StatusNew, <-ch)
+
+	require.NoError(t, machine.Transition(transitions.StatusBooting))
+	require.Eventually(t, func() bool {
+		select {
+		case state := <-ch:
+			return assert.Equal(t, transitions.StatusBooting, state)
+		default:
+			return false
+		}
+	}, 100*time.Millisecond, 10*time.Millisecond, "the deprecated alias should deliver transitions")
 }
 
 func TestFSM_IsTransitionAllowed(t *testing.T) {

--- a/hooks/broadcast/README.md
+++ b/hooks/broadcast/README.md
@@ -2,7 +2,7 @@
 
 Provides state change notifications through channels when registered as a post-transition hook.
 
-**Note:** For most use cases, use the built-in `machine.GetStateChan()` method instead of manually configuring a broadcast manager. This package is for advanced scenarios requiring custom broadcast logic, multiple managers, or fine-grained hook control. See the [main README](../../README.md#subscribing-to-state-changes) for the simpler approach.
+**Note:** For most use cases, use the built-in `machine.Subscribe()` method instead of manually configuring a broadcast manager. This package is for advanced scenarios requiring custom broadcast logic, multiple managers, or fine-grained hook control. See the [main README](../../README.md#subscribing-to-state-changes) for the simpler approach.
 
 ## Usage
 

--- a/options.go
+++ b/options.go
@@ -56,8 +56,8 @@ func WithLogHandler(handler slog.Handler) Option {
 	}
 }
 
-// WithBroadcastTimeout sets the default timeout for broadcast delivery when using GetStateChan.
-// This option only affects the built-in machine.GetStateChan() method. If you manually configure
+// WithBroadcastTimeout sets the default timeout for broadcast delivery when using Subscribe.
+// This option only affects the built-in machine.Subscribe() method. If you manually configure
 // a broadcast.Manager and hooks.Registry, configure the timeout via broadcast.WithTimeout()
 // when calling broadcastManager.GetStateChan() instead.
 //

--- a/readme_test.go
+++ b/readme_test.go
@@ -338,7 +338,7 @@ func TestReadme_SubscribingToStateChanges(t *testing.T) {
 
 		// 3. Create a channel and register it
 		stateChan := make(chan string, 10)
-		err = machine.GetStateChan(ctx, stateChan)
+		err = machine.Subscribe(ctx, stateChan)
 		require.NoError(t, err)
 
 		// 4. Should receive initial state immediately


### PR DESCRIPTION
**PR 1 of 8** — splits #80 into reviewable pieces. Stack: **#1** → #2 → #3 → #4 → #5 → #6 → #7 → #8.

## Problem

`GetStateChan` describes the **v1** signature, which created and *returned* the channel:

```go
func (fsm *Machine) GetStateChan(ctx context.Context) <-chan string   // v1
```

Since v2 the caller supplies the channel, so the method gets you nothing — it registers a subscription and sends the current state. The name has described a signature that doesn't exist since v2.0.

## How this fixes it

Renames `Machine.GetStateChan` to `Machine.Subscribe`, identical signature. The old name remains as a thin `Deprecated:` wrapper, so **nothing breaks** — gopls, staticcheck and pkg.go.dev surface the replacement automatically.

`broadcast.Manager.GetStateChan` is **not** renamed. Its name was accurate all along: it genuinely creates (or, with `WithCustomChannel`, selects) and *returns* a channel. Renaming it would have added a second method plus a deprecated shim to the low-level package for symmetry alone.

Docs: `docs/v2-upgrade.md`'s v2-side code samples and quick-reference now target `machine.Subscribe(ctx, chan)` (a migrator following the guide should not land on deprecated API), and the troubleshooting heading matches the current error text. v1-side references (`stateChan := machine.GetStateChan(ctx)`) stay, since that is what v1 shipped. `hooks/broadcast/README.md`'s pointer to the built-in machine method is updated likewise; the `WithBroadcastTimeout` doc comment too.

## Tests

`TestGetStateChan_DeprecatedAliasDelegatesToSubscribe` — subscribes through the deprecated name and asserts the initial state and a subsequent transition are both delivered, proving the wrapper delegates correctly.

Rename-only otherwise: no behavior change. Net new exported API: `Machine.Subscribe` only.

https://claude.ai/code/session_01WMFFnBa2iXgQ8ZqMjfYREP
