### PR TITLE
fix(hooks): fire hooks once per transition and copy caller state slices

### DIFF
--- a/hooks/config.go
+++ b/hooks/config.go
@@ -37,6 +37,14 @@ func (h HookType) String() string {
 }
 
 // PreTransitionHookConfig contains configuration for registering a pre-transition hook.
+//
+// From and To are copied at registration, so the caller may reuse or mutate the
+// slices once the register call has returned. They must not be mutated
+// concurrently with the registration call itself, since copying reads them.
+//
+// Duplicate entries in From or To are ignored for matching purposes: the hook
+// fires once per matching transition regardless. GetHooks still reports the
+// patterns exactly as registered.
 type PreTransitionHookConfig struct {
 	Name  string
 	From  []string
@@ -45,6 +53,14 @@ type PreTransitionHookConfig struct {
 }
 
 // PostTransitionHookConfig contains configuration for registering a post-transition hook.
+//
+// From and To are copied at registration, so the caller may reuse or mutate the
+// slices once the register call has returned. They must not be mutated
+// concurrently with the registration call itself, since copying reads them.
+//
+// Duplicate entries in From or To are ignored for matching purposes: the hook
+// fires once per matching transition regardless. GetHooks still reports the
+// patterns exactly as registered.
 type PostTransitionHookConfig struct {
 	Name   string
 	From   []string

--- a/hooks/registry.go
+++ b/hooks/registry.go
@@ -237,10 +237,14 @@ func (r *Registry) RegisterPreTransitionHook(config PreTransitionHookConfig) err
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
+	// Clone the caller's slices: hookEntry.matches reads them from the executors,
+	// which snapshot the index under RLock and release it before iterating, so a
+	// later caller-side mutation would silently change matching and a concurrent
+	// one would be a data race.
 	entry := &hookEntry{
 		guard:      config.Guard,
-		fromStates: config.From,
-		toStates:   config.To,
+		fromStates: slices.Clone(config.From),
+		toStates:   slices.Clone(config.To),
 		hookType:   HookTypePre,
 	}
 
@@ -254,10 +258,11 @@ func (r *Registry) RegisterPostTransitionHook(config PostTransitionHookConfig) e
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
+	// Clone the caller's slices; see RegisterPreTransitionHook for why.
 	entry := &hookEntry{
 		action:     config.Action,
-		fromStates: config.From,
-		toStates:   config.To,
+		fromStates: slices.Clone(config.From),
+		toStates:   slices.Clone(config.To),
 		hookType:   HookTypePost,
 	}
 
@@ -387,25 +392,18 @@ func (r *Registry) registerHookEntry(name string, entry *hookEntry) error {
 // Assumes no wildcards are present in the patterns (caller must check first).
 // Validates that all state names exist in the transition table if provided.
 func (r *Registry) buildConcreteIndexKeys(fromPatterns, toPatterns []string) ([]transitionKey, error) {
-	// Validate and collect from states
-	var fromStates []string
-	for _, pattern := range fromPatterns {
-		if r.transitions != nil && !r.transitions.HasState(pattern) {
-			return nil, fmt.Errorf("unknown state '%s'", pattern)
-		}
-		fromStates = append(fromStates, pattern)
+	fromStates, err := r.validateUniqueStates(fromPatterns)
+	if err != nil {
+		return nil, err
 	}
 
-	// Validate and collect to states
-	var toStates []string
-	for _, pattern := range toPatterns {
-		if r.transitions != nil && !r.transitions.HasState(pattern) {
-			return nil, fmt.Errorf("unknown state '%s'", pattern)
-		}
-		toStates = append(toStates, pattern)
+	toStates, err := r.validateUniqueStates(toPatterns)
+	if err != nil {
+		return nil, err
 	}
 
-	// Compute cartesian product
+	// Compute cartesian product. Both operands are duplicate-free, so every key
+	// is unique and the entry is indexed at most once per transition.
 	keys := make([]transitionKey, 0, len(fromStates)*len(toStates))
 	for _, from := range fromStates {
 		for _, to := range toStates {
@@ -414,6 +412,37 @@ func (r *Registry) buildConcreteIndexKeys(fromPatterns, toPatterns []string) ([]
 	}
 
 	return keys, nil
+}
+
+// validateUniqueStates validates each pattern against the transition table (when
+// one is configured) and returns the patterns with duplicates removed,
+// preserving first-occurrence order.
+//
+// De-duplication matters because these patterns feed a cartesian product used as
+// index keys. A repeated state produces a repeated key, which appends the same
+// hookEntry to one index slot more than once, and the guard or action then runs
+// once per duplicate for a single transition. Duplicates are dropped silently
+// rather than rejected: programmatically-assembled state lists commonly contain
+// them and the intended meaning is unambiguous.
+//
+// Validation runs before the duplicate check so a repeated unknown state still
+// reports the unknown-state error rather than being silently collapsed.
+func (r *Registry) validateUniqueStates(patterns []string) ([]string, error) {
+	seen := make(map[string]struct{}, len(patterns))
+	unique := make([]string, 0, len(patterns))
+
+	for _, pattern := range patterns {
+		if r.transitions != nil && !r.transitions.HasState(pattern) {
+			return nil, fmt.Errorf("unknown state '%s'", pattern)
+		}
+		if _, dup := seen[pattern]; dup {
+			continue
+		}
+		seen[pattern] = struct{}{}
+		unique = append(unique, pattern)
+	}
+
+	return unique, nil
 }
 
 // safeCallGuard executes a guard with panic recovery.

--- a/hooks/registry_test.go
+++ b/hooks/registry_test.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"log/slog"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/robbyt/go-fsm/v2/transitions"
 	"github.com/stretchr/testify/assert"
@@ -1211,5 +1213,286 @@ func TestRegisterHook_NilFuncRejected(t *testing.T) {
 			Name: "ok-action", From: []string{"a"}, To: []string{"b"},
 			Action: func(ctx context.Context, from, to string) {},
 		}))
+	})
+}
+
+// TestRegisterHook_DuplicateStatesFireOnce verifies that duplicate entries in a
+// hook's From or To list do not index the same hookEntry more than once.
+// Before buildConcreteIndexKeys de-duplicated its patterns, the cartesian
+// product produced repeated transitionKeys, the entry was appended to one index
+// slot once per duplicate, and the guard or action ran once per duplicate for a
+// single transition.
+func TestRegisterHook_DuplicateStatesFireOnce(t *testing.T) {
+	t.Parallel()
+
+	trans := transitions.MustNew(map[string][]string{
+		"a": {"b", "c"},
+		"b": {},
+		"c": {},
+	})
+
+	t.Run("Duplicate from state fires a pre-transition hook once", func(t *testing.T) {
+		reg, err := NewRegistry(WithLogger(slog.Default()), WithTransitions(trans))
+		require.NoError(t, err)
+
+		calls := 0
+		require.NoError(t, reg.RegisterPreTransitionHook(PreTransitionHookConfig{
+			Name: "dup-from",
+			From: []string{"a", "a"},
+			To:   []string{"b"},
+			Guard: func(ctx context.Context, from, to string) error {
+				calls++
+				return nil
+			},
+		}))
+
+		require.NoError(t, reg.ExecutePreTransitionHooks(context.Background(), "a", "b"))
+		assert.Equal(t, 1, calls)
+	})
+
+	t.Run("Duplicate to state fires a post-transition hook once", func(t *testing.T) {
+		reg, err := NewRegistry(WithLogger(slog.Default()), WithTransitions(trans))
+		require.NoError(t, err)
+
+		calls := 0
+		require.NoError(t, reg.RegisterPostTransitionHook(PostTransitionHookConfig{
+			Name: "dup-to",
+			From: []string{"a"},
+			To:   []string{"b", "b"},
+			Action: func(ctx context.Context, from, to string) {
+				calls++
+			},
+		}))
+
+		reg.ExecutePostTransitionHooks(context.Background(), "a", "b")
+		assert.Equal(t, 1, calls)
+	})
+
+	t.Run("Duplicates in both lists fire once per matching transition", func(t *testing.T) {
+		reg, err := NewRegistry(WithLogger(slog.Default()), WithTransitions(trans))
+		require.NoError(t, err)
+
+		calls := make(map[string]int)
+		require.NoError(t, reg.RegisterPreTransitionHook(PreTransitionHookConfig{
+			Name: "dup-both",
+			From: []string{"a", "a"},
+			To:   []string{"b", "b", "c"},
+			Guard: func(ctx context.Context, from, to string) error {
+				calls[from+"->"+to]++
+				return nil
+			},
+		}))
+
+		require.NoError(t, reg.ExecutePreTransitionHooks(context.Background(), "a", "b"))
+		require.NoError(t, reg.ExecutePreTransitionHooks(context.Background(), "a", "c"))
+		assert.Equal(t, map[string]int{"a->b": 1, "a->c": 1}, calls)
+	})
+
+	t.Run("Distinct states still expand to the full cartesian product", func(t *testing.T) {
+		reg, err := NewRegistry(WithLogger(slog.Default()), WithTransitions(trans))
+		require.NoError(t, err)
+
+		calls := make(map[string]int)
+		require.NoError(t, reg.RegisterPreTransitionHook(PreTransitionHookConfig{
+			Name: "distinct",
+			From: []string{"a"},
+			To:   []string{"b", "c"},
+			Guard: func(ctx context.Context, from, to string) error {
+				calls[from+"->"+to]++
+				return nil
+			},
+		}))
+
+		require.NoError(t, reg.ExecutePreTransitionHooks(context.Background(), "a", "b"))
+		require.NoError(t, reg.ExecutePreTransitionHooks(context.Background(), "a", "c"))
+		assert.Equal(t, map[string]int{"a->b": 1, "a->c": 1}, calls)
+	})
+
+	t.Run("GetHooks reports the caller's patterns verbatim", func(t *testing.T) {
+		reg, err := NewRegistry(WithLogger(slog.Default()), WithTransitions(trans))
+		require.NoError(t, err)
+
+		require.NoError(t, reg.RegisterPreTransitionHook(PreTransitionHookConfig{
+			Name: "verbatim",
+			From: []string{"a", "a"},
+			To:   []string{"b", "b"},
+			Guard: func(ctx context.Context, from, to string) error {
+				return nil
+			},
+		}))
+
+		hooks := reg.GetHooks()
+		require.Len(t, hooks, 1)
+		// De-duplication is confined to index construction; the reported
+		// metadata is whatever the caller registered.
+		assert.Equal(t, []string{"a", "a"}, hooks[0].FromStates)
+		assert.Equal(t, []string{"b", "b"}, hooks[0].ToStates)
+	})
+
+	t.Run("Wildcard hook with duplicate states fires once", func(t *testing.T) {
+		reg, err := NewRegistry(WithLogger(slog.Default()), WithTransitions(trans))
+		require.NoError(t, err)
+
+		calls := 0
+		require.NoError(t, reg.RegisterPreTransitionHook(PreTransitionHookConfig{
+			Name: "dup-wildcard",
+			From: []string{"*", "*"},
+			To:   []string{"b", "b"},
+			Guard: func(ctx context.Context, from, to string) error {
+				calls++
+				return nil
+			},
+		}))
+
+		require.NoError(t, reg.ExecutePreTransitionHooks(context.Background(), "a", "b"))
+		assert.Equal(t, 1, calls)
+	})
+
+	t.Run("Repeated unknown state still reports the unknown state", func(t *testing.T) {
+		reg, err := NewRegistry(WithLogger(slog.Default()), WithTransitions(trans))
+		require.NoError(t, err)
+
+		err = reg.RegisterPreTransitionHook(PreTransitionHookConfig{
+			Name: "dup-unknown",
+			From: []string{"zzz", "zzz"},
+			To:   []string{"b"},
+			Guard: func(ctx context.Context, from, to string) error {
+				return nil
+			},
+		})
+		require.ErrorContains(t, err, "unknown state 'zzz'")
+	})
+}
+
+// TestRegisterHook_ConfigSlicesAreCopied verifies that registration does not
+// alias the caller's From/To slices. Before the register methods cloned them,
+// mutating the caller's slice silently changed matching (a wildcard hook could
+// be disabled outright), and mutating it concurrently with a transition was a
+// data race: hookEntry.matches reads those slices from the executors, which
+// snapshot the index under RLock and then release it before iterating.
+func TestRegisterHook_ConfigSlicesAreCopied(t *testing.T) {
+	t.Parallel()
+
+	trans := transitions.MustNew(map[string][]string{"a": {"b"}, "b": {}})
+
+	t.Run("Mutating From after registration does not change matching", func(t *testing.T) {
+		reg, err := NewRegistry(WithLogger(slog.Default()), WithTransitions(trans))
+		require.NoError(t, err)
+
+		from := []string{"a"}
+		calls := 0
+		require.NoError(t, reg.RegisterPreTransitionHook(PreTransitionHookConfig{
+			Name: "mut-from",
+			From: from,
+			To:   []string{"*"}, // wildcard forces runtime matching via hookEntry.matches
+			Guard: func(ctx context.Context, f, to string) error {
+				calls++
+				return nil
+			},
+		}))
+
+		from[0] = "zzz" // caller mutates their own slice after registration
+
+		require.NoError(t, reg.ExecutePreTransitionHooks(context.Background(), "a", "b"))
+		assert.Equal(t, 1, calls, "hook must still match the state it was registered with")
+	})
+
+	t.Run("Mutating To after registration does not change matching", func(t *testing.T) {
+		reg, err := NewRegistry(WithLogger(slog.Default()), WithTransitions(trans))
+		require.NoError(t, err)
+
+		to := []string{"b"}
+		calls := 0
+		require.NoError(t, reg.RegisterPostTransitionHook(PostTransitionHookConfig{
+			Name: "mut-to",
+			From: []string{"*"},
+			To:   to,
+			Action: func(ctx context.Context, f, t2 string) {
+				calls++
+			},
+		}))
+
+		to[0] = "zzz"
+
+		reg.ExecutePostTransitionHooks(context.Background(), "a", "b")
+		assert.Equal(t, 1, calls, "hook must still match the state it was registered with")
+	})
+
+	t.Run("Mutation is not visible through GetHooks", func(t *testing.T) {
+		reg, err := NewRegistry(WithLogger(slog.Default()), WithTransitions(trans))
+		require.NoError(t, err)
+
+		from := []string{"a"}
+		to := []string{"b"}
+		calls := 0
+		require.NoError(t, reg.RegisterPreTransitionHook(PreTransitionHookConfig{
+			Name: "mut-both",
+			From: from,
+			To:   to,
+			Guard: func(ctx context.Context, f, t2 string) error {
+				calls++
+				return nil
+			},
+		}))
+
+		from[0] = "zzz"
+		to[0] = "zzz"
+
+		hooks := reg.GetHooks()
+		require.Len(t, hooks, 1)
+		assert.Equal(t, []string{"a"}, hooks[0].FromStates)
+		assert.Equal(t, []string{"b"}, hooks[0].ToStates)
+
+		// The concrete index key was built from the original values too.
+		require.NoError(t, reg.ExecutePreTransitionHooks(context.Background(), "a", "b"))
+		assert.Equal(t, 1, calls)
+	})
+
+	t.Run("Concurrent mutation and execution is race-free", func(t *testing.T) {
+		reg, err := NewRegistry(WithLogger(slog.Default()), WithTransitions(trans))
+		require.NoError(t, err)
+
+		from := []string{"a"}
+		var executions atomic.Int64
+		require.NoError(t, reg.RegisterPreTransitionHook(PreTransitionHookConfig{
+			Name: "racy",
+			From: from,
+			To:   []string{"*"}, // wildcard: matches runs on every execution
+			Guard: func(ctx context.Context, f, to string) error {
+				executions.Add(1)
+				return nil
+			},
+		}))
+
+		stop := make(chan struct{})
+		var wg sync.WaitGroup
+		wg.Go(func() {
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					if err := reg.ExecutePreTransitionHooks(context.Background(), "a", "b"); err != nil {
+						t.Errorf("unexpected hook error: %v", err)
+						return
+					}
+				}
+			}
+		})
+		// Always stop and join the executor goroutine, even if the loop below
+		// fails early, so it cannot outlive the test.
+		t.Cleanup(func() {
+			close(stop)
+			wg.Wait()
+		})
+
+		// Mutate the caller's slice while the executor reads the registry's copy.
+		// Wait for real overlap rather than assuming the goroutine got scheduled:
+		// without executions the race detector would have nothing to observe.
+		require.Eventually(t, func() bool {
+			from[0] = "zzz"
+			from[0] = "a"
+			return executions.Load() > 100
+		}, 500*time.Millisecond, time.Millisecond, "executor goroutine never overlapped with the mutations")
 	})
 }


### PR DESCRIPTION
**PR 2 of 8** — splits #80. Stack: #1 → **#2** → #3 → #4 → #5 → #6 → #7 → #8. Base: #81.

Two registration defects in `hooks.Registry`, both in one file and one concern. (An earlier revision also added three error sentinels for the registry's validation paths; that was dropped to keep the exported surface small — the plain error strings from `main` are unchanged.)

## Problem 1 — a duplicated state fires the hook twice

`buildConcreteIndexKeys` built the `From × To` cartesian product with no de-duplication, so:

```go
reg.RegisterPreTransitionHook(hooks.PreTransitionHookConfig{
    From: []string{"a", "a"}, To: []string{"b"}, Guard: guard,
})
```
appended the same `hookEntry` to the `{a,b}` index slot **twice**. The guard ran twice for one transition. For post-transition hooks that means side effects fire twice — duplicate notifications, duplicate writes.

**Fix:** patterns are de-duplicated in a new `validateUniqueStates` helper before the product is computed. Validation still runs *before* the dedupe, so a repeated unknown state still errors rather than being silently collapsed. `GetHooks` continues to report the caller's patterns verbatim — de-duplication is confined to index construction.

**Test:** `TestRegisterHook_DuplicateStatesFireOnce` — covers duplicate `From`, duplicate `To`, both, pre- and post-transition hooks, wildcards, and that *distinct* states still expand to the full cartesian product (guarding against an over-eager dedupe). Without the fix the guard fires 2× instead of 1×, and 4×/2× for the both-lists case.

## Problem 2 — registration aliased the caller's slices

`hookEntry.fromStates`/`toStates` pointed at the caller's slices. `hookEntry.matches` reads them from the executors, which snapshot the index under `RLock` and **release it before iterating** — so a later caller-side mutation silently changed matching (mutating a wildcard hook's `From` disabled it outright), and a concurrent mutation was a straight data race.

**Fix:** `slices.Clone` in both register methods, matching the defensive-copy pattern already used by `transitions.New` and `GetHooks`.

**Test:** `TestRegisterHook_ConfigSlicesAreCopied`, including a `-race` subtest that counts executions to guarantee real overlap. Without the fix the race detector fires and all four subtests fail.


https://claude.ai/code/session_01WMFFnBa2iXgQ8ZqMjfYREP
