### PR TITLE
fix(broadcast): stop leaking a cleanup goroutine per subscription

### DIFF
--- a/hooks/broadcast/manager.go
+++ b/hooks/broadcast/manager.go
@@ -38,6 +38,19 @@ type subscription struct {
 	// is abandoned instead of holding the manager mutex forever. It is nil for a
 	// non-cancellable context, and a nil channel is never ready.
 	ctxDone <-chan struct{}
+
+	// departed is closed exactly once when this subscription ends, by either
+	// context cancellation or an explicit unsubscribe. Broadcast selects on it
+	// alongside ctxDone so an explicit unsubscribe can release a parked send.
+	departed   chan struct{}
+	signalOnce sync.Once
+
+	// stopAfterFunc releases this subscription's context.AfterFunc association.
+	// It is assigned under Manager.mu before the subscription is published, and
+	// is only ever read by UnsubscribeAll, which reaches the subscription through
+	// the map and so observes the write. depart must never call it: on the
+	// context path depart IS the callback.
+	stopAfterFunc func() bool
 }
 
 // key returns the map key for this subscription. Subscribers are keyed by the
@@ -47,11 +60,34 @@ func (s *subscription) key() <-chan string {
 	return s.ch
 }
 
+// signalDepart marks this subscription as ended, releasing any broadcast
+// currently parked on a blocking send to it. Safe to call repeatedly and from
+// any goroutine; it deliberately takes no lock, because callers must be able to
+// signal before contending for the manager mutex.
+func (s *subscription) signalDepart() {
+	s.signalOnce.Do(func() { close(s.departed) })
+}
+
 // Manager handles state change notifications to subscribers.
 type Manager struct {
-	mu          sync.Mutex
+	mu sync.Mutex
+
+	// subscribers maps <-chan string to *subscription.
+	//
+	// The locking discipline here is deliberately path-dependent, and a future
+	// change to a plain map must preserve both halves:
+	//
+	//   - GetStateChan arms context cleanup and stores under mu, because the pair
+	//     has to be atomic (see GetStateChan).
+	//   - UnsubscribeAll's first pass reads WITHOUT mu, because it must signal
+	//     departure before contending for a mutex that a broadcast parked on a
+	//     blocking send is holding.
+	//
+	// A plain map would therefore need its own second mutex for the unlocked
+	// reads; reusing mu for them reintroduces the deadlock.
 	subscribers sync.Map
-	logger      *slog.Logger
+
+	logger *slog.Logger
 }
 
 // NewManager creates a new broadcast manager.
@@ -64,10 +100,20 @@ func NewManager(handler slog.Handler) *Manager {
 	}
 }
 
-// GetStateChan returns a channel that receives state change notifications.
-// The channel is automatically closed when ctx is cancelled.
+// GetStateChan registers for state change notifications and returns the channel
+// they will be delivered on.
 // Use functional options to customize buffer size, timeout behavior, or provide a custom channel.
 // Returns an error if ctx is nil.
+//
+// Cancelling ctx ends the subscription; UnsubscribeAll ends every subscription
+// at once. A manager-owned channel is closed when the subscription ends; a
+// channel supplied via WithCustomChannel belongs to its caller, who is
+// responsible for closing it and must not do so while it is still subscribed.
+//
+// Passing a non-cancellable context (context.Background()) is supported and
+// costs nothing, but leaves UnsubscribeAll as the only way to end the
+// subscription, so a subscriber that is simply dropped stays registered for the
+// lifetime of the manager. Prefer a cancellable context.
 func (m *Manager) GetStateChan(ctx context.Context, opts ...Option) (<-chan string, error) {
 	if ctx == nil {
 		return nil, fmt.Errorf("context cannot be nil")
@@ -83,6 +129,7 @@ func (m *Manager) GetStateChan(ctx context.Context, opts ...Option) (<-chan stri
 		timeout:         config.timeout,
 		externalChannel: config.externalChannel,
 		ctxDone:         ctx.Done(),
+		departed:        make(chan struct{}),
 	}
 
 	if config.channel != nil {
@@ -95,21 +142,64 @@ func (m *Manager) GetStateChan(ctx context.Context, opts ...Option) (<-chan stri
 		sub.externalChannel = false
 	}
 
-	// Register subscriber
+	// Register the subscriber and arm context cleanup as one critical section.
+	//
+	// context.AfterFunc runs its callback immediately, on a fresh goroutine, when
+	// the context is already cancelled -- so arming it outside the lock would let
+	// that callback finish departing before the Store below published the
+	// subscription, leaving a departed (and possibly closed) entry in the map.
+	// Holding m.mu across arm-and-store closes that window: depart signals
+	// without a lock but cannot reach its removal until we release, at which
+	// point it correctly removes what we just stored.
+	//
+	// AfterFunc also replaces a `go func() { <-ctx.Done(); ... }()` cleanup
+	// goroutine. For a non-cancellable context (context.Background()) it
+	// registers nothing and starts nothing, so such a subscriber no longer leaks
+	// a parked goroutine; it lives until UnsubscribeAll.
 	m.mu.Lock()
+	sub.stopAfterFunc = context.AfterFunc(ctx, func() { m.depart(sub) })
 	m.subscribers.Store(sub.key(), sub)
 	m.mu.Unlock()
 
-	// Handle cleanup when context is cancelled
-	go func() {
-		<-ctx.Done()
-		m.depart(sub)
-		if !sub.externalChannel {
+	return sub.ch, nil
+}
+
+// UnsubscribeAll ends every current subscription. It is used to release all
+// subscribers at once when tearing down whatever owns this manager.
+//
+// Unlike a context cancellation, UnsubscribeAll cannot be delayed by the broadcast it is
+// trying to release: it signals every subscription it can see before acquiring
+// the manager mutex, so any parked send has already been given its exit.
+//
+// A subscription created concurrently with UnsubscribeAll is included if and
+// only if it completed registration before the second pass acquired the mutex.
+func (m *Manager) UnsubscribeAll() {
+	// Phase 1: signal without the mutex, freeing any parked broadcast so that
+	// phase 2 can acquire m.mu.
+	seen := make(map[*subscription]struct{})
+	for sub := range m.iterSubscribers() {
+		sub.signalDepart()
+		seen[sub] = struct{}{}
+	}
+
+	// Phase 2: under the mutex, remove everything still registered. Ranging
+	// again picks up any subscription that won the mutex ahead of us.
+	m.mu.Lock()
+	for sub := range m.iterSubscribers() {
+		sub.signalDepart()
+		seen[sub] = struct{}{}
+		if _, loaded := m.subscribers.LoadAndDelete(sub.key()); loaded && !sub.externalChannel {
 			close(sub.ch)
 		}
-	}()
+	}
+	m.mu.Unlock()
 
-	return sub.ch, nil
+	// Phase 3: release the context associations for everything either pass saw,
+	// so a later cancellation neither runs depart nor keeps the subscription
+	// reachable from its context.
+	for sub := range seen {
+		sub.stopAfterFunc()
+	}
 }
 
 // Broadcast sends the state to all subscriber channels.
@@ -131,12 +221,14 @@ func (m *Manager) Broadcast(state string) {
 
 	for sub := range m.iterSubscribers() {
 		ch := sub.ch
-		// ctxDone is the subscriber's context cancellation signal. Selecting on
-		// it in the blocking branches ensures a subscriber that has gone away
-		// (its context was cancelled) cannot block the broadcast indefinitely
-		// while the manager mutex is held, which would otherwise deadlock
-		// departure and every future Broadcast.
+		// departed and ctxDone are the subscriber's departure signals. Selecting
+		// on them in the blocking branches ensures a subscriber that has gone
+		// away -- its context was cancelled, or it was explicitly unsubscribed --
+		// cannot block the broadcast indefinitely while the manager mutex is
+		// held, which would otherwise deadlock departure and every future
+		// Broadcast.
 		done := sub.ctxDone
+		departed := sub.departed
 		if sub.timeout < 0 {
 			// Negative timeout: block until delivered or the subscriber departs
 			// (guaranteed delivery for live subscribers).
@@ -146,6 +238,8 @@ func (m *Manager) Broadcast(state string) {
 					logger.Debug("State delivered to guaranteed delivery subscriber")
 				case <-done:
 					logger.Debug("Guaranteed-delivery subscriber departed before delivery; aborting send")
+				case <-departed:
+					logger.Debug("Guaranteed-delivery subscriber unsubscribed before delivery; aborting send")
 				}
 			})
 		} else if sub.timeout > 0 {
@@ -157,6 +251,8 @@ func (m *Manager) Broadcast(state string) {
 					logger.Debug("State delivered to timeout subscriber")
 				case <-done:
 					logger.Debug("Timeout subscriber departed before delivery; aborting send")
+				case <-departed:
+					logger.Debug("Timeout subscriber unsubscribed before delivery; aborting send")
 				case <-time.After(timeout):
 					logger.Warn("Timeout subscriber blocked; state delivery timed out",
 						"timeout", timeout,
@@ -187,11 +283,32 @@ func (m *Manager) BroadcastHook(_ context.Context, _, to string) {
 	m.Broadcast(to)
 }
 
-// depart removes a subscription from receiving broadcasts.
+// depart ends a subscription: it releases any in-flight blocking send to it,
+// removes it from the subscriber set, and closes the channel when the manager
+// owns it. Idempotent and safe to call from any goroutine.
+//
+// The ordering is load-bearing. departed is closed BEFORE m.mu is acquired:
+// Broadcast holds m.mu for the whole broadcast and may be parked in a blocking
+// send to this subscriber, so signalling first lets that send abort and the
+// mutex drop. Acquiring m.mu afterwards is what makes removal synchronous --
+// once depart returns, no broadcast is sending on this channel.
 func (m *Manager) depart(sub *subscription) {
+	sub.signalDepart()
+
 	m.mu.Lock()
-	m.subscribers.Delete(sub.key())
-	m.mu.Unlock()
+	defer m.mu.Unlock()
+
+	// LoadAndDelete rather than a bare Delete so that the removal reports
+	// whether it was this call that took the entry out. depart and
+	// UnsubscribeAll can both target the same subscription -- a context
+	// cancelled while UnsubscribeAll is running, say -- and both close
+	// manager-owned channels; the mutex serialises them, and only the one that
+	// actually removed the entry closes.
+	if _, loaded := m.subscribers.LoadAndDelete(sub.key()); loaded && !sub.externalChannel {
+		// Closing under m.mu is the send/close barrier: broadcasts hold the same
+		// mutex and wait for their send goroutines, so none is in flight here.
+		close(sub.ch)
+	}
 }
 
 // iterSubscribers returns a sequence of all current subscriptions.

--- a/hooks/broadcast/manager.go
+++ b/hooks/broadcast/manager.go
@@ -33,24 +33,12 @@ type subscription struct {
 	timeout         time.Duration
 	externalChannel bool
 
-	// ctxDone is the subscriber's context cancellation signal. Broadcast selects
-	// on it so a blocking send to a subscriber whose context has been cancelled
-	// is abandoned instead of holding the manager mutex forever. It is nil for a
-	// non-cancellable context, and a nil channel is never ready.
-	ctxDone <-chan struct{}
-
-	// departed is closed exactly once when this subscription ends, by either
-	// context cancellation or an explicit unsubscribe. Broadcast selects on it
-	// alongside ctxDone so an explicit unsubscribe can release a parked send.
-	departed   chan struct{}
-	signalOnce sync.Once
-
-	// stopAfterFunc releases this subscription's context.AfterFunc association.
-	// It is assigned under Manager.mu before the subscription is published, and
-	// is only ever read by UnsubscribeAll, which reaches the subscription through
-	// the map and so observes the write. depart must never call it: on the
-	// context path depart IS the callback.
-	stopAfterFunc func() bool
+	// done is closed when the subscription ends, whether by the subscriber's
+	// context being cancelled or by UnsubscribeAll -- both go through cancel.
+	// Broadcast selects on it so a blocking send to a subscriber that has gone
+	// away is abandoned instead of holding the manager mutex forever.
+	done   <-chan struct{}
+	cancel context.CancelFunc
 }
 
 // key returns the map key for this subscription. Subscribers are keyed by the
@@ -60,31 +48,14 @@ func (s *subscription) key() <-chan string {
 	return s.ch
 }
 
-// signalDepart marks this subscription as ended, releasing any broadcast
-// currently parked on a blocking send to it. Safe to call repeatedly and from
-// any goroutine; it deliberately takes no lock, because callers must be able to
-// signal before contending for the manager mutex.
-func (s *subscription) signalDepart() {
-	s.signalOnce.Do(func() { close(s.departed) })
-}
-
 // Manager handles state change notifications to subscribers.
 type Manager struct {
 	mu sync.Mutex
 
-	// subscribers maps <-chan string to *subscription.
-	//
-	// The locking discipline here is deliberately path-dependent, and a future
-	// change to a plain map must preserve both halves:
-	//
-	//   - GetStateChan arms context cleanup and stores under mu, because the pair
-	//     has to be atomic (see GetStateChan).
-	//   - UnsubscribeAll's first pass reads WITHOUT mu, because it must signal
-	//     departure before contending for a mutex that a broadcast parked on a
-	//     blocking send is holding.
-	//
-	// A plain map would therefore need its own second mutex for the unlocked
-	// reads; reusing mu for them reintroduces the deadlock.
+	// subscribers maps <-chan string to *subscription. UnsubscribeAll ranges
+	// over it WITHOUT mu on its first pass, because it must signal departure
+	// before contending for a mutex that a parked broadcast may be holding; a
+	// plain map would need its own second lock for that.
 	subscribers sync.Map
 
 	logger *slog.Logger
@@ -125,11 +96,16 @@ func (m *Manager) GetStateChan(ctx context.Context, opts ...Option) (<-chan stri
 		opt(config)
 	}
 
+	// Each subscription gets its own cancellable context derived from the
+	// caller's. Cancelling either one ends it; cancel is idempotent; and a
+	// cancelled child detaches from its parent, so an ended subscription holds
+	// no reference from a long-lived caller context.
+	subCtx, cancel := context.WithCancel(ctx)
 	sub := &subscription{
 		timeout:         config.timeout,
 		externalChannel: config.externalChannel,
-		ctxDone:         ctx.Done(),
-		departed:        make(chan struct{}),
+		done:            subCtx.Done(),
+		cancel:          cancel,
 	}
 
 	if config.channel != nil {
@@ -142,24 +118,16 @@ func (m *Manager) GetStateChan(ctx context.Context, opts ...Option) (<-chan stri
 		sub.externalChannel = false
 	}
 
-	// Register the subscriber and arm context cleanup as one critical section.
-	//
-	// context.AfterFunc runs its callback immediately, on a fresh goroutine, when
-	// the context is already cancelled -- so arming it outside the lock would let
-	// that callback finish departing before the Store below published the
-	// subscription, leaving a departed (and possibly closed) entry in the map.
-	// Holding m.mu across arm-and-store closes that window: depart signals
-	// without a lock but cannot reach its removal until we release, at which
-	// point it correctly removes what we just stored.
-	//
-	// AfterFunc also replaces a `go func() { <-ctx.Done(); ... }()` cleanup
-	// goroutine. For a non-cancellable context (context.Background()) it
-	// registers nothing and starts nothing, so such a subscriber no longer leaks
-	// a parked goroutine; it lives until UnsubscribeAll.
 	m.mu.Lock()
-	sub.stopAfterFunc = context.AfterFunc(ctx, func() { m.depart(sub) })
 	m.subscribers.Store(sub.key(), sub)
 	m.mu.Unlock()
+
+	// context.AfterFunc replaces a `go func() { <-ctx.Done(); ... }()` cleanup
+	// goroutine: it starts nothing until the context is actually cancelled, so a
+	// subscriber on a non-cancellable context no longer leaks a parked
+	// goroutine. Armed after the Store so an already-cancelled context finds
+	// the entry it has to remove.
+	context.AfterFunc(subCtx, func() { m.remove(sub) })
 
 	return sub.ch, nil
 }
@@ -167,38 +135,20 @@ func (m *Manager) GetStateChan(ctx context.Context, opts ...Option) (<-chan stri
 // UnsubscribeAll ends every current subscription. It is used to release all
 // subscribers at once when tearing down whatever owns this manager.
 //
-// Unlike a context cancellation, UnsubscribeAll cannot be delayed by the broadcast it is
-// trying to release: it signals every subscription it can see before acquiring
-// the manager mutex, so any parked send has already been given its exit.
-//
-// A subscription created concurrently with UnsubscribeAll is included if and
-// only if it completed registration before the second pass acquired the mutex.
+// It signals every subscription before acquiring the manager mutex, so a
+// broadcast parked on a blocking send is released rather than waited on. A
+// subscription created concurrently is included if and only if it was stored
+// before the second pass acquired the mutex.
 func (m *Manager) UnsubscribeAll() {
-	// Phase 1: signal without the mutex, freeing any parked broadcast so that
-	// phase 2 can acquire m.mu.
-	seen := make(map[*subscription]struct{})
 	for sub := range m.iterSubscribers() {
-		sub.signalDepart()
-		seen[sub] = struct{}{}
+		sub.cancel()
 	}
 
-	// Phase 2: under the mutex, remove everything still registered. Ranging
-	// again picks up any subscription that won the mutex ahead of us.
 	m.mu.Lock()
+	defer m.mu.Unlock()
 	for sub := range m.iterSubscribers() {
-		sub.signalDepart()
-		seen[sub] = struct{}{}
-		if _, loaded := m.subscribers.LoadAndDelete(sub.key()); loaded && !sub.externalChannel {
-			close(sub.ch)
-		}
-	}
-	m.mu.Unlock()
-
-	// Phase 3: release the context associations for everything either pass saw,
-	// so a later cancellation neither runs depart nor keeps the subscription
-	// reachable from its context.
-	for sub := range seen {
-		sub.stopAfterFunc()
+		sub.cancel()
+		m.removeLocked(sub)
 	}
 }
 
@@ -221,14 +171,10 @@ func (m *Manager) Broadcast(state string) {
 
 	for sub := range m.iterSubscribers() {
 		ch := sub.ch
-		// departed and ctxDone are the subscriber's departure signals. Selecting
-		// on them in the blocking branches ensures a subscriber that has gone
-		// away -- its context was cancelled, or it was explicitly unsubscribed --
-		// cannot block the broadcast indefinitely while the manager mutex is
-		// held, which would otherwise deadlock departure and every future
-		// Broadcast.
-		done := sub.ctxDone
-		departed := sub.departed
+		// done is the subscriber's departure signal. Selecting on it in the
+		// blocking branches ensures a subscriber that has gone away cannot block
+		// the broadcast indefinitely while the manager mutex is held.
+		done := sub.done
 		if sub.timeout < 0 {
 			// Negative timeout: block until delivered or the subscriber departs
 			// (guaranteed delivery for live subscribers).
@@ -238,8 +184,6 @@ func (m *Manager) Broadcast(state string) {
 					logger.Debug("State delivered to guaranteed delivery subscriber")
 				case <-done:
 					logger.Debug("Guaranteed-delivery subscriber departed before delivery; aborting send")
-				case <-departed:
-					logger.Debug("Guaranteed-delivery subscriber unsubscribed before delivery; aborting send")
 				}
 			})
 		} else if sub.timeout > 0 {
@@ -251,8 +195,6 @@ func (m *Manager) Broadcast(state string) {
 					logger.Debug("State delivered to timeout subscriber")
 				case <-done:
 					logger.Debug("Timeout subscriber departed before delivery; aborting send")
-				case <-departed:
-					logger.Debug("Timeout subscriber unsubscribed before delivery; aborting send")
 				case <-time.After(timeout):
 					logger.Warn("Timeout subscriber blocked; state delivery timed out",
 						"timeout", timeout,
@@ -283,30 +225,23 @@ func (m *Manager) BroadcastHook(_ context.Context, _, to string) {
 	m.Broadcast(to)
 }
 
-// depart ends a subscription: it releases any in-flight blocking send to it,
-// removes it from the subscriber set, and closes the channel when the manager
-// owns it. Idempotent and safe to call from any goroutine.
-//
-// The ordering is load-bearing. departed is closed BEFORE m.mu is acquired:
-// Broadcast holds m.mu for the whole broadcast and may be parked in a blocking
-// send to this subscriber, so signalling first lets that send abort and the
-// mutex drop. Acquiring m.mu afterwards is what makes removal synchronous --
-// once depart returns, no broadcast is sending on this channel.
-func (m *Manager) depart(sub *subscription) {
-	sub.signalDepart()
-
+// remove takes an ended subscription out of the subscriber set and closes its
+// channel if the manager owns it. It runs after the subscription's context is
+// cancelled, so any broadcast parked on this subscriber has already been
+// released; acquiring m.mu is what makes the removal synchronous with respect
+// to broadcasts.
+func (m *Manager) remove(sub *subscription) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	m.removeLocked(sub)
+}
 
-	// LoadAndDelete rather than a bare Delete so that the removal reports
-	// whether it was this call that took the entry out. depart and
-	// UnsubscribeAll can both target the same subscription -- a context
-	// cancelled while UnsubscribeAll is running, say -- and both close
-	// manager-owned channels; the mutex serialises them, and only the one that
-	// actually removed the entry closes.
+// removeLocked is remove with m.mu already held. LoadAndDelete so that only
+// the caller that actually removed the entry closes a manager-owned channel:
+// the context AfterFunc and UnsubscribeAll can both target the same
+// subscription, and the mutex serialises them.
+func (m *Manager) removeLocked(sub *subscription) {
 	if _, loaded := m.subscribers.LoadAndDelete(sub.key()); loaded && !sub.externalChannel {
-		// Closing under m.mu is the send/close barrier: broadcasts hold the same
-		// mutex and wait for their send goroutines, so none is in flight here.
 		close(sub.ch)
 	}
 }

--- a/hooks/broadcast/manager_test.go
+++ b/hooks/broadcast/manager_test.go
@@ -597,3 +597,103 @@ func TestGetStateChan_NilCustomChannelIsManagerOwned(t *testing.T) {
 		t.Fatal("channel was not closed after cancellation; nil custom channel was wrongly treated as external")
 	}
 }
+
+// TestGetStateChan_BackgroundContextSpawnsNoGoroutine verifies that subscribing
+// with a non-cancellable context does not start a per-subscriber cleanup
+// goroutine. Previously every GetStateChan spawned `go func(){ <-ctx.Done(); ...
+// }()`, which for context.Background() parked forever: the goroutine and its map
+// entry leaked for the life of the process.
+func TestGetStateChan_BackgroundContextSpawnsNoGoroutine(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		manager := broadcast.NewManager(newTestLogger().Handler())
+
+		for range 3 {
+			ch, err := manager.GetStateChan(context.Background(), broadcast.WithBufferSize(1))
+			require.NoError(t, err)
+			require.NotNil(t, ch)
+		}
+
+		// On the old code three goroutines are durably blocked on a nil Done()
+		// channel here, and the bubble fails with a deadlock.
+		synctest.Wait()
+
+		manager.UnsubscribeAll()
+	})
+}
+
+// TestUnsubscribeAll_EndsEverySubscriptionEvenWhenBroadcastIsBlocked verifies
+// that UnsubscribeAll releases a parked broadcast and clears every subscriber,
+// closing the manager-owned ones.
+//
+// Parameterised over both blocking delivery modes deliberately. Guaranteed
+// delivery (-1) exercises the path that has always selected on departure; a
+// positive timeout exercises the branch that did not, where UnsubscribeAll
+// could only proceed once the timeout elapsed -- so tearing down a manager
+// blocked for up to the broadcast timeout despite documenting otherwise.
+func TestUnsubscribeAll_EndsEverySubscriptionEvenWhenBroadcastIsBlocked(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name    string
+		timeout time.Duration
+	}{
+		{name: "Guaranteed delivery", timeout: -1},
+		{name: "Long positive timeout", timeout: time.Hour},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				manager := broadcast.NewManager(newTestLogger().Handler())
+
+				blocked := make(chan string, 1)
+				_, err := manager.GetStateChan(
+					context.Background(),
+					broadcast.WithCustomChannel(blocked),
+					broadcast.WithTimeout(tc.timeout),
+				)
+				require.NoError(t, err)
+
+				owned, err := manager.GetStateChan(context.Background(), broadcast.WithBufferSize(1))
+				require.NoError(t, err)
+
+				manager.Broadcast("first")
+
+				broadcastDone := false
+				go func() {
+					manager.Broadcast("second")
+					broadcastDone = true
+				}()
+
+				synctest.Wait()
+				require.False(t, broadcastDone, "broadcast should be parked on the full channel")
+
+				manager.UnsubscribeAll()
+
+				// synctest.Wait returns once every goroutine is durably blocked.
+				// With the fake clock this cannot be satisfied by the timeout
+				// elapsing, so a pass here means departure released the send.
+				synctest.Wait()
+				assert.True(t, broadcastDone, "UnsubscribeAll should release the parked broadcast")
+
+				// Drain any buffered value, then confirm the manager-owned channel closed.
+				for range len(owned) {
+					<-owned
+				}
+				_, open := <-owned
+				assert.False(t, open, "manager-owned channel should be closed by UnsubscribeAll")
+
+				// The caller owns the custom channel, so UnsubscribeAll must leave
+				// it open -- and unsubscribed, so nothing else is delivered to it.
+				require.Len(t, blocked, 1, "the value delivered before the park should still be buffered")
+				assert.Equal(t, "first", <-blocked)
+
+				manager.Broadcast("third")
+				synctest.Wait()
+				assert.Empty(t, blocked, "an unsubscribed channel should receive no further broadcasts")
+
+				close(blocked)
+			})
+		})
+	}
+}

--- a/hooks/broadcast/manager_test.go
+++ b/hooks/broadcast/manager_test.go
@@ -615,11 +615,11 @@ func TestGetStateChan_BackgroundContextSpawnsNoGoroutine(t *testing.T) {
 			require.NotNil(t, ch)
 		}
 
-		// On the old code three goroutines are durably blocked on a nil Done()
-		// channel here, and the bubble fails with a deadlock.
+		// Deliberately no UnsubscribeAll: the defect is that a subscriber that is
+		// simply dropped leaves a goroutine parked forever. synctest fails the
+		// bubble if any goroutine is still blocked when it exits, so reaching the
+		// end with the three subscriptions still registered is the assertion.
 		synctest.Wait()
-
-		manager.UnsubscribeAll()
 	})
 }
 
@@ -696,4 +696,51 @@ func TestUnsubscribeAll_EndsEverySubscriptionEvenWhenBroadcastIsBlocked(t *testi
 			})
 		})
 	}
+}
+
+// TestGetStateChan_NoGoroutineOutlivesTheSubscription pins, with synctest, that
+// ending a subscription by either route leaves nothing behind: a synctest bubble
+// fails if any goroutine is still parked when it exits, which is exactly the
+// leak the AfterFunc-based cleanup exists to prevent.
+func TestGetStateChan_NoGoroutineOutlivesTheSubscription(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Context cancellation", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			manager := broadcast.NewManager(newTestLogger().Handler())
+			ctx, cancel := context.WithCancel(t.Context())
+
+			ch, err := manager.GetStateChan(ctx, broadcast.WithBufferSize(1))
+			require.NoError(t, err)
+
+			cancel()
+			synctest.Wait()
+
+			_, open := <-ch
+			assert.False(t, open, "manager-owned channel should be closed after cancellation")
+			// Bubble exit asserts no goroutine remains.
+		})
+	})
+
+	t.Run("UnsubscribeAll then a late context cancellation", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			manager := broadcast.NewManager(newTestLogger().Handler())
+			ctx, cancel := context.WithCancel(t.Context())
+
+			ch, err := manager.GetStateChan(ctx, broadcast.WithBufferSize(1))
+			require.NoError(t, err)
+
+			manager.UnsubscribeAll()
+			synctest.Wait()
+			_, open := <-ch
+			assert.False(t, open, "manager-owned channel should be closed by UnsubscribeAll")
+
+			// The caller's context outlived the subscription. Cancelling it now
+			// must be a no-op: no second close, no goroutine left parked.
+			cancel()
+			synctest.Wait()
+
+			manager.Broadcast("after")
+		})
+	})
 }


### PR DESCRIPTION
**PR 4 of 8** — splits #80. Stack: #1 → #2 → #3 → **#4** → #5 → #6 → #7 → #8. Base: #83.

## Problem

Every subscription spawned a watcher goroutine:

```go
go func() {
    <-ctx.Done()
    m.unsubscribe(ch)
    ...
}()
```

With a non-cancellable context — `context.Background()` — `ctx.Done()` returns nil, which is **never ready**. The goroutine parks forever and its map entry is never released. Both leak for the life of the process, and there was no other way to end such a subscription.

## How this fixes it

Replaces the goroutine with `context.AfterFunc`. For a non-cancellable context it registers *nothing at all* — the leak is gone by construction rather than by giving a leaked goroutine an exit. It also drops the parent context's reference to the closure, which is the memory half of the leak.

Adds `UnsubscribeAll` so an owner can release every subscriber at once (used by `Machine.Close` in #8).

Each subscription gets its own context derived from the caller's via `context.WithCancel`, and that context **is** the departure mechanism: its `Done` channel is what `Broadcast` selects on in the blocking branches, `cancel` is idempotent and lock-free, cancelling either the caller's context or the subscription's ends it, and a cancelled child detaches from its parent so nothing has to be "stopped" afterwards. The `AfterFunc` is armed on the derived context and only removes the map entry.

### One ordering is load-bearing

`Broadcast` holds the manager mutex for its **entire** duration, including `wg.Wait()`. So `UnsubscribeAll` cancels every subscription *before* taking `m.mu`: a send parked on a full channel is released first, rather than deadlocked against. Removing that pre-lock pass hangs the suite — verified.

(The second commit replaces an earlier hand-rolled version of the departure signal — a `departed` channel + `sync.Once` + `stopAfterFunc` + three-phase teardown — with the derived-context form above; net implementation footprint vs `main` goes from +117 to +52 lines. Kept as a separate commit rather than an amend so the branches above rebase cleanly.)

### Also fixed here

`Broadcast`'s `timeout > 0` branch selected only on the context and the timeout — **not** on departure. So `UnsubscribeAll` could not release a parked timeout-mode send and had to wait out the full timeout, despite documenting otherwise. Adds the missing case.

## Tests

All `testing/synctest` bubbles — a bubble fails if any goroutine is still parked when it exits, which is exactly the leak under test.

- `TestGetStateChan_BackgroundContextSpawnsNoGoroutine` — three dropped `Background()` subscribers, deliberately **no** teardown. Without the fix the bubble fails with *"blocked goroutines remain"*.
- `TestGetStateChan_NoGoroutineOutlivesTheSubscription` — ending by context cancellation, and by `UnsubscribeAll` followed by a *late* cancellation of the caller's context (no double close, nothing parked, manager still broadcasts).
- `TestUnsubscribeAll_EndsEverySubscriptionEvenWhenBroadcastIsBlocked` — **table-driven over both blocking modes**: guaranteed delivery (`-1`) *and* a long positive timeout. The positive-timeout case is the regression test for the defect above. Verified red: without the pre-lock cancel pass it hangs, because under the fake clock `time.After(time.Hour)` never fires.

https://claude.ai/code/session_01WMFFnBa2iXgQ8ZqMjfYREP

