### PR TITLE
fix(fsm): reject a nil state channel before it can wedge the machine

### DIFF
--- a/fsm.go
+++ b/fsm.go
@@ -56,7 +56,10 @@ import (
 // (GetAllStates, HasState, IsTransitionAllowed all run lock-free), so any
 // locking or copying needed for read safety is the implementation's
 // responsibility. The bundled transitions.Config satisfies this contract:
-// its index is built once at construction and never mutated.
+// its index is built once at construction and never mutated. The one exception
+// is transitions.Config.UnmarshalJSON, which rebuilds the config in place; see
+// its doc comment. Never unmarshal into a Config that is already attached to a
+// Machine.
 type transitionDB interface {
 	HasState(state string) bool
 	GetAllStates() []string
@@ -364,9 +367,14 @@ func (fsm *Machine) transition(ctx context.Context, toState string) error {
 // send honors the provided context — if ctx is cancelled while it is blocked, Subscribe returns
 // the context's error.
 //
-// This method requires the FSM to be configured with a hooks.Registry (via WithCallbackRegistry).
-// The registry must be created with WithTransitions() to support wildcard pattern matching.
-// Returns an error if the callback executor does not support dynamic hook registration.
+// This method requires the FSM to be configured (via WithCallbackRegistry) with a
+// CallbackExecutor that also implements HookRegistrar, such as a hooks.Registry.
+// A hooks.Registry must be created with WithTransitions() to support wildcard pattern matching.
+//
+// Errors: a nil ctx, a nil channel, a missing callback registry, or a registry that
+// does not support dynamic hook registration all return an error wrapping
+// ErrInvalidConfiguration. Subscribing a channel that is already subscribed returns
+// an error while the first subscription is live.
 //
 // The channel will automatically receive all future state transitions until the context
 // is cancelled, at which point it is automatically unsubscribed from receiving further broadcasts.
@@ -389,7 +397,8 @@ func (fsm *Machine) transition(ctx context.Context, toState string) error {
 //
 // The channel must be bidirectional (chan string, not <-chan string) to allow the FSM
 // to send state updates. The caller maintains ownership of the channel and controls
-// its buffer size and lifecycle.
+// its buffer size and lifecycle. It must be non-nil; a nil channel is rejected
+// without registering a subscriber.
 //
 // Example:
 //
@@ -424,16 +433,28 @@ func (fsm *Machine) transition(ctx context.Context, toState string) error {
 //	}()
 func (fsm *Machine) Subscribe(ctx context.Context, c chan string) error {
 	if ctx == nil {
-		return fmt.Errorf("context cannot be nil")
+		return fmt.Errorf("%w: context cannot be nil", ErrInvalidConfiguration)
+	}
+
+	// Reject a nil channel before anything is registered. A nil channel makes the
+	// initial-state send below block forever, and because that send happens under
+	// the FSM read lock it would wedge every subsequent Transition, SetState, and
+	// MarshalJSON on this machine, with no way to recover when the context is not
+	// cancellable.
+	if c == nil {
+		return fmt.Errorf("%w: state channel cannot be nil", ErrInvalidConfiguration)
 	}
 
 	if fsm.callbacks == nil {
-		return fmt.Errorf("Subscribe requires a callback registry")
+		return fmt.Errorf("%w: Subscribe requires a callback registry", ErrInvalidConfiguration)
 	}
 
 	registrar, ok := fsm.callbacks.(HookRegistrar)
 	if !ok {
-		return fmt.Errorf("Subscribe requires a callback registry that supports dynamic hook registration")
+		return fmt.Errorf(
+			"%w: Subscribe requires a callback registry that supports dynamic hook registration",
+			ErrInvalidConfiguration,
+		)
 	}
 
 	fsm.stateChanSetup.Do(func() {
@@ -478,7 +499,7 @@ func (fsm *Machine) Subscribe(ctx context.Context, c chan string) error {
 	// Honor the context during the initial send so a full/unbuffered channel
 	// cannot block here (and thus block transitions, since we hold the read
 	// lock) past the caller's cancellation. The subscriber is unsubscribed by
-	// the same ctx cancellation via the broadcast manager's cleanup goroutine.
+	// the same ctx cancellation, via the broadcast manager.
 	select {
 	case c <- fsm.GetState():
 	case <-ctx.Done():

--- a/fsm_test.go
+++ b/fsm_test.go
@@ -114,6 +114,15 @@ func (m *mockCallbackExecutor) getReceivedContexts() []context.Context {
 	return append([]context.Context(nil), m.receivedContexts...)
 }
 
+// mustSubscribe registers ch on m and fails the test if registration errors.
+// It returns the unsubscribe handle, which most callers ignore because the test
+// context ends the subscription.
+func mustSubscribe(t *testing.T, m *Machine, ctx context.Context, ch chan string) {
+	t.Helper()
+
+	require.NoError(t, m.Subscribe(ctx, ch))
+}
+
 // Unit tests with mocked dependencies
 func TestFSM_New_Validation(t *testing.T) {
 	t.Parallel()
@@ -673,6 +682,7 @@ func TestFSM_Subscribe(t *testing.T) {
 		//nolint:staticcheck // Intentionally testing nil context error
 		err = fsm.Subscribe(nil, c)
 		require.Error(t, err)
+		require.ErrorIs(t, err, ErrInvalidConfiguration)
 		assert.Contains(t, err.Error(), "context cannot be nil")
 	})
 
@@ -688,6 +698,7 @@ func TestFSM_Subscribe(t *testing.T) {
 		c := make(chan string, 1)
 		err = fsm.Subscribe(ctx, c)
 		require.Error(t, err)
+		require.ErrorIs(t, err, ErrInvalidConfiguration)
 		assert.Contains(t, err.Error(), "Subscribe requires a callback registry")
 	})
 
@@ -704,6 +715,7 @@ func TestFSM_Subscribe(t *testing.T) {
 		c := make(chan string, 1)
 		err = fsm.Subscribe(ctx, c)
 		require.Error(t, err)
+		require.ErrorIs(t, err, ErrInvalidConfiguration)
 		assert.Contains(t, err.Error(), "requires a callback registry that supports dynamic hook registration")
 	})
 
@@ -987,11 +999,17 @@ func TestSubscribe_InitialSendIsAtomic(t *testing.T) {
 	}
 }
 
-// TestSubscribe_InitialSendRespectsContext verifies that the initial-state
-// send honors the context: with an unbuffered channel and no reader the send
-// blocks, and a cancelled context makes Subscribe return the context error
-// instead of hanging while holding the FSM read lock.
-func TestSubscribe_InitialSendRespectsContext(t *testing.T) {
+// TestSubscribe_AlreadyCancelledContextRejected verifies that subscribing with
+// an already-cancelled context is rejected, deterministically, before anything
+// is registered.
+//
+// This test previously claimed to cover the initial-state send aborting on
+// cancellation, but once Subscribe began rejecting already-cancelled contexts up
+// front it never reached that send -- it passed for the wrong reason, because
+// the rejection error also wraps context.Canceled. The genuine mid-flight case
+// is covered by TestSubscribe_InitialSendCancelledMidFlight; this one now
+// asserts the behaviour it actually exercises.
+func TestSubscribe_AlreadyCancelledContextRejected(t *testing.T) {
 	t.Parallel()
 
 	reg, err := hooks.NewRegistry(hooks.WithTransitions(transitions.Typical))
@@ -1000,12 +1018,15 @@ func TestSubscribe_InitialSendRespectsContext(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	cancel() // cancel up front so the blocked initial send aborts
+	cancel()
 
-	ch := make(chan string) // unbuffered, no reader: the initial send blocks
+	ch := make(chan string, 1)
 	err = machine.Subscribe(ctx, ch)
-	require.Error(t, err)
-	assert.ErrorIs(t, err, context.Canceled)
+	require.ErrorIs(t, err, context.Canceled)
+
+	// Rejected before registration: the channel is free to subscribe under a
+	// live context, which a lingering entry would refuse as a duplicate.
+	require.NoError(t, machine.Subscribe(t.Context(), ch))
 }
 
 // TestGetStateChan_DeprecatedAliasDelegatesToSubscribe verifies that the
@@ -1098,5 +1119,95 @@ func TestFSM_IsTerminal(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.False(t, machine.IsTerminal(), "Unknown self-loops, so it is not terminal")
+	})
+}
+
+// TestSubscribe_NilChannelRejected verifies that a nil channel is rejected
+// before any state is touched. Previously the nil channel fell through to the
+// initial-state send, which blocks forever on a nil channel while holding the
+// FSM read lock; with a non-cancellable context that permanently wedged every
+// Transition, SetState, and MarshalJSON call on the machine.
+func TestSubscribe_NilChannelRejected(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Returns ErrInvalidConfiguration and leaves the machine usable", func(t *testing.T) {
+		reg, err := hooks.NewRegistry(hooks.WithTransitions(transitions.Typical))
+		require.NoError(t, err)
+		machine, err := New(transitions.StatusNew, transitions.Typical, WithCallbackRegistry(reg))
+		require.NoError(t, err)
+
+		err = machine.Subscribe(context.Background(), nil)
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrInvalidConfiguration)
+		require.ErrorContains(t, err, "state channel cannot be nil")
+
+		// The rejection happens before setup, so no broadcast hook was registered.
+		assert.Empty(t, reg.GetHooks())
+
+		// The read lock was never taken: transitions still work.
+		require.NoError(t, machine.Transition(transitions.StatusBooting))
+		assert.Equal(t, transitions.StatusBooting, machine.GetState())
+
+		// Setup was not consumed: a later valid subscription still succeeds.
+		ch := make(chan string, 1)
+		mustSubscribe(t, machine, t.Context(), ch)
+		assert.Equal(t, transitions.StatusBooting, <-ch)
+	})
+
+	t.Run("Spawns no goroutine and registers no subscriber", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			reg, err := hooks.NewRegistry(hooks.WithTransitions(transitions.Typical))
+			require.NoError(t, err)
+			machine, err := New(transitions.StatusNew, transitions.Typical, WithCallbackRegistry(reg))
+			require.NoError(t, err)
+
+			// context.Background() is deliberate: on the old code both this call
+			// and the manager's cleanup goroutine block on it forever, which the
+			// bubble reports as a deadlock.
+			require.ErrorIs(t, machine.Subscribe(context.Background(), nil), ErrInvalidConfiguration)
+			synctest.Wait()
+
+			require.NoError(t, machine.Transition(transitions.StatusBooting))
+		})
+	})
+}
+
+// TestSubscribe_InitialSendCancelledMidFlight covers the initial-send
+// cancellation path. Its sibling, TestSubscribe_InitialSendRespectsContext,
+// pre-cancels the context and so is now rejected by the broadcast manager before
+// the send is ever reached; this exercises a cancellation that lands while the
+// send is genuinely blocked on a full channel.
+func TestSubscribe_InitialSendCancelledMidFlight(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		reg, err := hooks.NewRegistry(hooks.WithTransitions(transitions.Typical))
+		require.NoError(t, err)
+		machine, err := New(transitions.StatusNew, transitions.Typical, WithCallbackRegistry(reg))
+		require.NoError(t, err)
+
+		ctx, cancel := context.WithCancel(t.Context())
+		ch := make(chan string) // unbuffered, no reader: the initial send blocks
+
+		var subErr error
+		done := make(chan struct{})
+		go func() {
+			subErr = machine.Subscribe(ctx, ch)
+			close(done)
+		}()
+
+		// Let the subscription reach the blocked send before cancelling.
+		synctest.Wait()
+		select {
+		case <-done:
+			t.Fatal("Subscribe returned before the initial send could block")
+		default:
+		}
+
+		cancel()
+		synctest.Wait()
+
+		<-done
+		require.ErrorIs(t, subErr, context.Canceled)
 	})
 }

--- a/hooks/broadcast/README.md
+++ b/hooks/broadcast/README.md
@@ -38,18 +38,49 @@ machine, _ := fsm.New(transitions.StatusNew, transitions.Typical,
 	fsm.WithCallbackRegistry(registry))
 
 // Subscribe to state changes
-ctx := context.Background()
+ctx, cancel := context.WithCancel(context.Background())
+defer cancel()
+
 stateChan, _ := manager.GetStateChan(ctx)
 
 for state := range stateChan {
-	// Handle state change
+	// Handle state change; the loop ends when cancel() closes the channel.
+	_ = state
 }
 ```
+
+## Ending a Subscription
+
+A subscription ends when its context is cancelled, or when `UnsubscribeAll`
+releases every subscriber at once:
+
+```go
+// Ends every subscription, e.g. when tearing down whatever owns this manager.
+manager.UnsubscribeAll()
+```
+
+A manager-owned channel — one created by `WithBufferSize`, or by default — is
+closed when its subscription ends, so a `for range` over it terminates. A channel
+supplied via `WithCustomChannel` belongs to its caller: the manager never closes
+it, and you must not close it while it is still subscribed.
+
+Subscribing with a non-cancellable context such as `context.Background()` is
+supported and costs nothing, but leaves `UnsubscribeAll` as the only way to end
+the subscription, so a subscriber that is simply dropped stays registered for the
+life of the manager. Prefer a cancellable context. An already-cancelled context
+is rejected, and a channel may hold only one live subscription per manager:
+subscribing the same channel twice returns an error while the first
+subscription is live.
 
 ## Delivery Modes
 
 - **Best-effort (default)**: Non-blocking, drops messages if channel is full
 - **Timeout**: `WithTimeout(5*time.Second)` - blocks up to duration
 - **Guaranteed**: `WithTimeout(-1)` - blocks indefinitely until delivered
+
+> **Note:** when this manager is driven by a post-transition hook, broadcasts run
+> while the FSM write lock is held. A slow subscriber therefore delays *every*
+> transition for up to the configured timeout, and guaranteed delivery to a
+> subscriber that never drains halts the machine entirely.
 
 See [godoc](https://pkg.go.dev/github.com/robbyt/go-fsm/v2/hooks/broadcast) for details.

--- a/hooks/broadcast/manager.go
+++ b/hooks/broadcast/manager.go
@@ -68,6 +68,22 @@ func (s *subscription) signalDepart() {
 	s.signalOnce.Do(func() { close(s.departed) })
 }
 
+// live reports whether this subscription still receives broadcasts. Departure
+// counts as dead as well as context cancellation: teardown signals departure
+// before it can acquire the manager mutex, and a Subscribe that wins the
+// mutex in that window must see the slot as free rather than rejecting the new
+// registration as a duplicate.
+func (s *subscription) live() bool {
+	select {
+	case <-s.departed:
+		return false
+	case <-s.ctxDone: // nil for a non-cancellable context, and never ready
+		return false
+	default:
+		return true
+	}
+}
+
 // Manager handles state change notifications to subscribers.
 type Manager struct {
 	mu sync.Mutex
@@ -77,8 +93,9 @@ type Manager struct {
 	// The locking discipline here is deliberately path-dependent, and a future
 	// change to a plain map must preserve both halves:
 	//
-	//   - GetStateChan arms context cleanup and stores under mu, because the pair
-	//     has to be atomic (see GetStateChan).
+	//   - GetStateChan does its duplicate Load and its Store under mu, because
+	//     the pair has to be atomic or two concurrent registrations of the same
+	//     channel both succeed.
 	//   - UnsubscribeAll's first pass reads WITHOUT mu, because it must signal
 	//     departure before contending for a mutex that a broadcast parked on a
 	//     blocking send is holding.
@@ -113,10 +130,22 @@ func NewManager(handler slog.Handler) *Manager {
 // Passing a non-cancellable context (context.Background()) is supported and
 // costs nothing, but leaves UnsubscribeAll as the only way to end the
 // subscription, so a subscriber that is simply dropped stays registered for the
-// lifetime of the manager. Prefer a cancellable context.
+// lifetime of the manager. Prefer a cancellable context. An already-cancelled
+// context is rejected.
+//
+// A channel may hold only one live subscription per manager: subscribing the
+// same channel twice returns an error while the first subscription is live.
+// Re-subscribing a channel whose previous subscription has ended is allowed,
+// as is subscribing one channel to several managers.
 func (m *Manager) GetStateChan(ctx context.Context, opts ...Option) (<-chan string, error) {
 	if ctx == nil {
 		return nil, fmt.Errorf("context cannot be nil")
+	}
+
+	// Reject an already-cancelled context rather than registering a subscription
+	// that is dead on arrival and would be torn down again immediately.
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("cannot subscribe with a cancelled context: %w", err)
 	}
 
 	config := &Config{}
@@ -149,14 +178,27 @@ func (m *Manager) GetStateChan(ctx context.Context, opts ...Option) (<-chan stri
 	// that callback finish departing before the Store below published the
 	// subscription, leaving a departed (and possibly closed) entry in the map.
 	// Holding m.mu across arm-and-store closes that window: depart signals
-	// without a lock but cannot reach its removal until we release, at which
-	// point it correctly removes what we just stored.
+	// without a lock but cannot reach its CompareAndDelete until we release, at
+	// which point it correctly removes what we just stored.
 	//
 	// AfterFunc also replaces a `go func() { <-ctx.Done(); ... }()` cleanup
 	// goroutine. For a non-cancellable context (context.Background()) it
 	// registers nothing and starts nothing, so such a subscriber no longer leaks
 	// a parked goroutine; it lives until UnsubscribeAll.
+	//
+	// The duplicate check shares this critical section: splitting it from the
+	// Store would let two concurrent registrations of the same channel both pass.
 	m.mu.Lock()
+	if value, loaded := m.subscribers.Load(sub.key()); loaded {
+		if existing, ok := value.(*subscription); ok && existing.live() {
+			m.mu.Unlock()
+			return nil, fmt.Errorf("channel is already subscribed")
+		}
+		// The entry is dead: its context was cancelled, or an unsubscribe
+		// signalled departure and is still waiting for this mutex. Take the slot
+		// over -- depart uses CompareAndDelete, so the older teardown cannot
+		// evict us.
+	}
 	sub.stopAfterFunc = context.AfterFunc(ctx, func() { m.depart(sub) })
 	m.subscribers.Store(sub.key(), sub)
 	m.mu.Unlock()
@@ -188,15 +230,15 @@ func (m *Manager) UnsubscribeAll() {
 	for sub := range m.iterSubscribers() {
 		sub.signalDepart()
 		seen[sub] = struct{}{}
-		if _, loaded := m.subscribers.LoadAndDelete(sub.key()); loaded && !sub.externalChannel {
+		if m.subscribers.CompareAndDelete(sub.key(), sub) && !sub.externalChannel {
 			close(sub.ch)
 		}
 	}
 	m.mu.Unlock()
 
-	// Phase 3: release the context associations for everything either pass saw,
-	// so a later cancellation neither runs depart nor keeps the subscription
-	// reachable from its context.
+	// Phase 3: release the context associations for everything either pass saw.
+	// A take-over can make phase 1 observe an old record and phase 2 its
+	// replacement, so both need stopping.
 	for sub := range seen {
 		sub.stopAfterFunc()
 	}
@@ -298,13 +340,10 @@ func (m *Manager) depart(sub *subscription) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	// LoadAndDelete rather than a bare Delete so that the removal reports
-	// whether it was this call that took the entry out. depart and
-	// UnsubscribeAll can both target the same subscription -- a context
-	// cancelled while UnsubscribeAll is running, say -- and both close
-	// manager-owned channels; the mutex serialises them, and only the one that
-	// actually removed the entry closes.
-	if _, loaded := m.subscribers.LoadAndDelete(sub.key()); loaded && !sub.externalChannel {
+	// CompareAndDelete rather than Delete: the same channel may already have been
+	// re-subscribed under a new subscription, and a late departure must neither
+	// evict that newer entry nor close the channel it is now using.
+	if m.subscribers.CompareAndDelete(sub.key(), sub) && !sub.externalChannel {
 		// Closing under m.mu is the send/close barrier: broadcasts hold the same
 		// mutex and wait for their send goroutines, so none is in flight here.
 		close(sub.ch)

--- a/hooks/broadcast/manager.go
+++ b/hooks/broadcast/manager.go
@@ -38,6 +38,19 @@ type subscription struct {
 	// is abandoned instead of holding the manager mutex forever. It is nil for a
 	// non-cancellable context, and a nil channel is never ready.
 	ctxDone <-chan struct{}
+
+	// departed is closed exactly once when this subscription ends, by either
+	// context cancellation or an explicit unsubscribe. Broadcast selects on it
+	// alongside ctxDone so an explicit unsubscribe can release a parked send.
+	departed   chan struct{}
+	signalOnce sync.Once
+
+	// stopAfterFunc releases this subscription's context.AfterFunc association.
+	// It is assigned under Manager.mu before the subscription is published, and
+	// is only ever read by UnsubscribeAll, which reaches the subscription through
+	// the map and so observes the write. depart must never call it: on the
+	// context path depart IS the callback.
+	stopAfterFunc func() bool
 }
 
 // key returns the map key for this subscription. Subscribers are keyed by the
@@ -47,11 +60,34 @@ func (s *subscription) key() <-chan string {
 	return s.ch
 }
 
+// signalDepart marks this subscription as ended, releasing any broadcast
+// currently parked on a blocking send to it. Safe to call repeatedly and from
+// any goroutine; it deliberately takes no lock, because callers must be able to
+// signal before contending for the manager mutex.
+func (s *subscription) signalDepart() {
+	s.signalOnce.Do(func() { close(s.departed) })
+}
+
 // Manager handles state change notifications to subscribers.
 type Manager struct {
-	mu          sync.Mutex
+	mu sync.Mutex
+
+	// subscribers maps <-chan string to *subscription.
+	//
+	// The locking discipline here is deliberately path-dependent, and a future
+	// change to a plain map must preserve both halves:
+	//
+	//   - GetStateChan arms context cleanup and stores under mu, because the pair
+	//     has to be atomic (see GetStateChan).
+	//   - UnsubscribeAll's first pass reads WITHOUT mu, because it must signal
+	//     departure before contending for a mutex that a broadcast parked on a
+	//     blocking send is holding.
+	//
+	// A plain map would therefore need its own second mutex for the unlocked
+	// reads; reusing mu for them reintroduces the deadlock.
 	subscribers sync.Map
-	logger      *slog.Logger
+
+	logger *slog.Logger
 }
 
 // NewManager creates a new broadcast manager.
@@ -64,10 +100,20 @@ func NewManager(handler slog.Handler) *Manager {
 	}
 }
 
-// GetStateChan returns a channel that receives state change notifications.
-// The channel is automatically closed when ctx is cancelled.
+// GetStateChan registers for state change notifications and returns the channel
+// they will be delivered on.
 // Use functional options to customize buffer size, timeout behavior, or provide a custom channel.
 // Returns an error if ctx is nil.
+//
+// Cancelling ctx ends the subscription; UnsubscribeAll ends every subscription
+// at once. A manager-owned channel is closed when the subscription ends; a
+// channel supplied via WithCustomChannel belongs to its caller, who is
+// responsible for closing it and must not do so while it is still subscribed.
+//
+// Passing a non-cancellable context (context.Background()) is supported and
+// costs nothing, but leaves UnsubscribeAll as the only way to end the
+// subscription, so a subscriber that is simply dropped stays registered for the
+// lifetime of the manager. Prefer a cancellable context.
 func (m *Manager) GetStateChan(ctx context.Context, opts ...Option) (<-chan string, error) {
 	if ctx == nil {
 		return nil, fmt.Errorf("context cannot be nil")
@@ -83,6 +129,7 @@ func (m *Manager) GetStateChan(ctx context.Context, opts ...Option) (<-chan stri
 		timeout:         config.timeout,
 		externalChannel: config.externalChannel,
 		ctxDone:         ctx.Done(),
+		departed:        make(chan struct{}),
 	}
 
 	if config.channel != nil {
@@ -95,21 +142,64 @@ func (m *Manager) GetStateChan(ctx context.Context, opts ...Option) (<-chan stri
 		sub.externalChannel = false
 	}
 
-	// Register subscriber
+	// Register the subscriber and arm context cleanup as one critical section.
+	//
+	// context.AfterFunc runs its callback immediately, on a fresh goroutine, when
+	// the context is already cancelled -- so arming it outside the lock would let
+	// that callback finish departing before the Store below published the
+	// subscription, leaving a departed (and possibly closed) entry in the map.
+	// Holding m.mu across arm-and-store closes that window: depart signals
+	// without a lock but cannot reach its removal until we release, at which
+	// point it correctly removes what we just stored.
+	//
+	// AfterFunc also replaces a `go func() { <-ctx.Done(); ... }()` cleanup
+	// goroutine. For a non-cancellable context (context.Background()) it
+	// registers nothing and starts nothing, so such a subscriber no longer leaks
+	// a parked goroutine; it lives until UnsubscribeAll.
 	m.mu.Lock()
+	sub.stopAfterFunc = context.AfterFunc(ctx, func() { m.depart(sub) })
 	m.subscribers.Store(sub.key(), sub)
 	m.mu.Unlock()
 
-	// Handle cleanup when context is cancelled
-	go func() {
-		<-ctx.Done()
-		m.depart(sub)
-		if !sub.externalChannel {
+	return sub.ch, nil
+}
+
+// UnsubscribeAll ends every current subscription. It is used to release all
+// subscribers at once when tearing down whatever owns this manager.
+//
+// Unlike a context cancellation, UnsubscribeAll cannot be delayed by the broadcast it is
+// trying to release: it signals every subscription it can see before acquiring
+// the manager mutex, so any parked send has already been given its exit.
+//
+// A subscription created concurrently with UnsubscribeAll is included if and
+// only if it completed registration before the second pass acquired the mutex.
+func (m *Manager) UnsubscribeAll() {
+	// Phase 1: signal without the mutex, freeing any parked broadcast so that
+	// phase 2 can acquire m.mu.
+	seen := make(map[*subscription]struct{})
+	for sub := range m.iterSubscribers() {
+		sub.signalDepart()
+		seen[sub] = struct{}{}
+	}
+
+	// Phase 2: under the mutex, remove everything still registered. Ranging
+	// again picks up any subscription that won the mutex ahead of us.
+	m.mu.Lock()
+	for sub := range m.iterSubscribers() {
+		sub.signalDepart()
+		seen[sub] = struct{}{}
+		if _, loaded := m.subscribers.LoadAndDelete(sub.key()); loaded && !sub.externalChannel {
 			close(sub.ch)
 		}
-	}()
+	}
+	m.mu.Unlock()
 
-	return sub.ch, nil
+	// Phase 3: release the context associations for everything either pass saw,
+	// so a later cancellation neither runs depart nor keeps the subscription
+	// reachable from its context.
+	for sub := range seen {
+		sub.stopAfterFunc()
+	}
 }
 
 // Broadcast sends the state to all subscriber channels.
@@ -131,12 +221,14 @@ func (m *Manager) Broadcast(state string) {
 
 	for sub := range m.iterSubscribers() {
 		ch := sub.ch
-		// ctxDone is the subscriber's context cancellation signal. Selecting on
-		// it in the blocking branches ensures a subscriber that has gone away
-		// (its context was cancelled) cannot block the broadcast indefinitely
-		// while the manager mutex is held, which would otherwise deadlock
-		// departure and every future Broadcast.
+		// departed and ctxDone are the subscriber's departure signals. Selecting
+		// on them in the blocking branches ensures a subscriber that has gone
+		// away -- its context was cancelled, or it was explicitly unsubscribed --
+		// cannot block the broadcast indefinitely while the manager mutex is
+		// held, which would otherwise deadlock departure and every future
+		// Broadcast.
 		done := sub.ctxDone
+		departed := sub.departed
 		if sub.timeout < 0 {
 			// Negative timeout: block until delivered or the subscriber departs
 			// (guaranteed delivery for live subscribers).
@@ -146,6 +238,8 @@ func (m *Manager) Broadcast(state string) {
 					logger.Debug("State delivered to guaranteed delivery subscriber")
 				case <-done:
 					logger.Debug("Guaranteed-delivery subscriber departed before delivery; aborting send")
+				case <-departed:
+					logger.Debug("Guaranteed-delivery subscriber unsubscribed before delivery; aborting send")
 				}
 			})
 		} else if sub.timeout > 0 {
@@ -157,6 +251,8 @@ func (m *Manager) Broadcast(state string) {
 					logger.Debug("State delivered to timeout subscriber")
 				case <-done:
 					logger.Debug("Timeout subscriber departed before delivery; aborting send")
+				case <-departed:
+					logger.Debug("Timeout subscriber unsubscribed before delivery; aborting send")
 				case <-time.After(timeout):
 					logger.Warn("Timeout subscriber blocked; state delivery timed out",
 						"timeout", timeout,
@@ -187,11 +283,32 @@ func (m *Manager) BroadcastHook(_ context.Context, _, to string) {
 	m.Broadcast(to)
 }
 
-// depart removes a subscription from receiving broadcasts.
+// depart ends a subscription: it releases any in-flight blocking send to it,
+// removes it from the subscriber set, and closes the channel when the manager
+// owns it. Idempotent and safe to call from any goroutine.
+//
+// The ordering is load-bearing. departed is closed BEFORE m.mu is acquired:
+// Broadcast holds m.mu for the whole broadcast and may be parked in a blocking
+// send to this subscriber, so signalling first lets that send abort and the
+// mutex drop. Acquiring m.mu afterwards is what makes removal synchronous --
+// once depart returns, no broadcast is sending on this channel.
 func (m *Manager) depart(sub *subscription) {
+	sub.signalDepart()
+
 	m.mu.Lock()
-	m.subscribers.Delete(sub.key())
-	m.mu.Unlock()
+	defer m.mu.Unlock()
+
+	// LoadAndDelete rather than a bare Delete so that the removal reports
+	// whether it was this call that took the entry out. depart and
+	// UnsubscribeAll can both target the same subscription -- a context
+	// cancelled while UnsubscribeAll is running, say -- and both close
+	// manager-owned channels; the mutex serialises them, and only the one that
+	// actually removed the entry closes.
+	if _, loaded := m.subscribers.LoadAndDelete(sub.key()); loaded && !sub.externalChannel {
+		// Closing under m.mu is the send/close barrier: broadcasts hold the same
+		// mutex and wait for their send goroutines, so none is in flight here.
+		close(sub.ch)
+	}
 }
 
 // iterSubscribers returns a sequence of all current subscriptions.

--- a/hooks/broadcast/manager_test.go
+++ b/hooks/broadcast/manager_test.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"log/slog"
 	"os"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -630,8 +632,8 @@ func TestGetStateChan_BackgroundContextSpawnsNoGoroutine(t *testing.T) {
 // Parameterised over both blocking delivery modes deliberately. Guaranteed
 // delivery (-1) exercises the path that has always selected on departure; a
 // positive timeout exercises the branch that did not, where UnsubscribeAll
-// could only proceed once the timeout elapsed -- so tearing down a manager
-// blocked for up to the broadcast timeout despite documenting otherwise.
+// could only proceed once the timeout elapsed -- so Machine.Close blocked for
+// up to the broadcast timeout despite documenting otherwise.
 func TestUnsubscribeAll_EndsEverySubscriptionEvenWhenBroadcastIsBlocked(t *testing.T) {
 	t.Parallel()
 
@@ -683,17 +685,235 @@ func TestUnsubscribeAll_EndsEverySubscriptionEvenWhenBroadcastIsBlocked(t *testi
 				_, open := <-owned
 				assert.False(t, open, "manager-owned channel should be closed by UnsubscribeAll")
 
-				// The caller owns the custom channel, so UnsubscribeAll must leave
-				// it open -- and unsubscribed, so nothing else is delivered to it.
-				require.Len(t, blocked, 1, "the value delivered before the park should still be buffered")
-				assert.Equal(t, "first", <-blocked)
-
-				manager.Broadcast("third")
-				synctest.Wait()
-				assert.Empty(t, blocked, "an unsubscribed channel should receive no further broadcasts")
-
-				close(blocked)
+				// The blocked subscriber was released, so its channel subscribes afresh
+				// rather than being rejected as a duplicate.
+				_, err = manager.GetStateChan(context.Background(), broadcast.WithCustomChannel(blocked))
+				require.NoError(t, err)
 			})
 		})
 	}
+}
+
+// TestGetStateChan_DuplicateChannelRejected verifies that a channel can hold
+// only one live subscription per manager. Subscribers are keyed by channel, so
+// a second registration used to silently overwrite the first's config and spawn
+// a second cleanup goroutine; cancelling the FIRST context then deleted the one
+// map entry and the second, still-live subscription stopped receiving with no
+// error.
+func TestGetStateChan_DuplicateChannelRejected(t *testing.T) {
+	t.Parallel()
+
+	manager := broadcast.NewManager(newTestLogger().Handler())
+	ch := make(chan string, 10)
+
+	ctx1, cancel1 := context.WithCancel(t.Context())
+	_, err := manager.GetStateChan(ctx1, broadcast.WithCustomChannel(ch))
+	require.NoError(t, err)
+
+	_, err = manager.GetStateChan(t.Context(), broadcast.WithCustomChannel(ch))
+	require.ErrorContains(t, err, "already subscribed")
+
+	// The rejected registration left the first subscription intact.
+	manager.Broadcast("StateA")
+	require.Eventually(t, func() bool {
+		select {
+		case state := <-ch:
+			return assert.Equal(t, "StateA", state)
+		default:
+			return false
+		}
+	}, 100*time.Millisecond, 10*time.Millisecond, "the original subscription should still be live")
+
+	// Exactly one copy: a duplicate registration would have delivered twice.
+	require.Never(t, func() bool {
+		select {
+		case <-ch:
+			return true
+		default:
+			return false
+		}
+	}, 100*time.Millisecond, 10*time.Millisecond, "state should be delivered exactly once")
+
+	cancel1()
+}
+
+// TestGetStateChan_ConcurrentDuplicateRegistrations verifies that the duplicate
+// check and the store are one atomic step: with N goroutines racing to subscribe
+// the same channel, exactly one must win.
+func TestGetStateChan_ConcurrentDuplicateRegistrations(t *testing.T) {
+	t.Parallel()
+
+	const racers = 8
+
+	manager := broadcast.NewManager(newTestLogger().Handler())
+	ch := make(chan string, racers)
+
+	var succeeded atomic.Int64
+	var wg sync.WaitGroup
+	for range racers {
+		wg.Go(func() {
+			if _, err := manager.GetStateChan(t.Context(), broadcast.WithCustomChannel(ch)); err == nil {
+				succeeded.Add(1)
+			}
+		})
+	}
+	wg.Wait()
+
+	assert.Equal(t, int64(1), succeeded.Load(), "exactly one concurrent registration should win")
+
+	// One subscription means one delivery.
+	manager.Broadcast("StateA")
+	require.Eventually(t, func() bool {
+		return len(ch) == 1
+	}, 100*time.Millisecond, 10*time.Millisecond, "expected exactly one delivery")
+}
+
+// TestGetStateChan_ResubscribeAfterCancelIsDeterministic verifies that a channel
+// whose subscription was just cancelled can be re-subscribed immediately, with
+// no wait for the teardown to finish. The take-over branch makes this
+// deterministic rather than a race between the new registration and the old
+// subscription's cleanup.
+func TestGetStateChan_ResubscribeAfterCancelIsDeterministic(t *testing.T) {
+	t.Parallel()
+
+	manager := broadcast.NewManager(newTestLogger().Handler())
+	ch := make(chan string, 10)
+
+	ctx1, cancel1 := context.WithCancel(t.Context())
+	_, err := manager.GetStateChan(ctx1, broadcast.WithCustomChannel(ch))
+	require.NoError(t, err)
+
+	cancel1()
+
+	// Deliberately no Eventually: this must succeed on the first attempt, even
+	// while the cancelled subscription's teardown is still in flight.
+	_, err = manager.GetStateChan(t.Context(), broadcast.WithCustomChannel(ch))
+	require.NoError(t, err, "re-subscribing after cancellation must be allowed immediately")
+
+	manager.Broadcast("StateA")
+	require.Eventually(t, func() bool {
+		select {
+		case state := <-ch:
+			return assert.Equal(t, "StateA", state)
+		default:
+			return false
+		}
+	}, 100*time.Millisecond, 10*time.Millisecond, "the new subscription should receive broadcasts")
+}
+
+// TestGetStateChan_CancelledContextRejected verifies that subscribing with an
+// already-cancelled context fails deterministically and leaves no phantom entry
+// behind.
+func TestGetStateChan_CancelledContextRejected(t *testing.T) {
+	t.Parallel()
+
+	manager := broadcast.NewManager(newTestLogger().Handler())
+	ch := make(chan string, 1)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	got, err := manager.GetStateChan(ctx, broadcast.WithCustomChannel(ch))
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Nil(t, got)
+
+	// No phantom subscription was registered: the channel subscribes cleanly,
+	// which a lingering live entry would reject as a duplicate.
+	_, err = manager.GetStateChan(t.Context(), broadcast.WithCustomChannel(ch))
+	require.NoError(t, err)
+}
+
+// TestGetStateChan_CancelRacingRegistration exercises a cancellation landing
+// during registration: the subscription must end up either rejected or fully
+// registered, never wedged in between.
+//
+// This is a smoke test for the interleaving, not a proof. The specific hazard --
+// context.AfterFunc firing its callback on a fresh goroutine when the context is
+// already done, completing teardown before the store publishes the subscription
+// and so stranding a departed entry in the map forever -- depends on a window
+// too narrow to hit on demand. Subscribe closes it by construction, by arming
+// AfterFunc and storing under the same acquisition of the manager mutex.
+func TestGetStateChan_CancelRacingRegistration(t *testing.T) {
+	t.Parallel()
+
+	for range 200 {
+		manager := broadcast.NewManager(newTestLogger().Handler())
+		ch := make(chan string, 1)
+
+		ctx, cancel := context.WithCancel(context.Background())
+
+		var wg sync.WaitGroup
+		wg.Go(cancel)
+		wg.Go(func() {
+			// Either outcome is legal: rejected as cancelled, or registered and
+			// then torn down. Neither may leave a live-looking zombie behind.
+			//nolint:errcheck // both outcomes are valid; the assertion is below
+			_, _ = manager.GetStateChan(ctx, broadcast.WithCustomChannel(ch))
+		})
+		wg.Wait()
+
+		// Whatever happened, the channel must be usable again.
+		require.Eventually(t, func() bool {
+			_, err := manager.GetStateChan(t.Context(), broadcast.WithCustomChannel(ch))
+			return err == nil
+		}, 100*time.Millisecond, time.Millisecond, "channel should be re-subscribable after the racing cancel")
+
+		manager.UnsubscribeAll()
+	}
+}
+
+// TestUnsubscribeAll_RacingNewRegistration verifies that UnsubscribeAll and a
+// concurrent registration cannot corrupt each other. A subscription that
+// completes registration before the second pass takes the mutex is released;
+// one that lands after it survives. Either way the manager stays consistent.
+func TestUnsubscribeAll_RacingNewRegistration(t *testing.T) {
+	t.Parallel()
+
+	for range 100 {
+		manager := broadcast.NewManager(newTestLogger().Handler())
+		ch := make(chan string, 1)
+
+		_, err := manager.GetStateChan(context.Background(), broadcast.WithBufferSize(1))
+		require.NoError(t, err)
+
+		var wg sync.WaitGroup
+		wg.Go(manager.UnsubscribeAll)
+		wg.Go(func() {
+			//nolint:errcheck // either side may win the race; the assertion is below
+			_, _ = manager.GetStateChan(context.Background(), broadcast.WithCustomChannel(ch))
+		})
+		wg.Wait()
+
+		// Broadcasting must not panic regardless of which side won.
+		assert.NotPanics(t, func() { manager.Broadcast("StateA") })
+		manager.UnsubscribeAll()
+	}
+}
+
+// TestGetStateChan_BufferSizeDeliveryAndNilContext verifies that a
+// manager-owned channel honours WithBufferSize, receives broadcasts, and that
+// a nil context is rejected.
+func TestGetStateChan_BufferSizeDeliveryAndNilContext(t *testing.T) {
+	t.Parallel()
+
+	manager := broadcast.NewManager(newTestLogger().Handler())
+
+	ch, err := manager.GetStateChan(t.Context(), broadcast.WithBufferSize(5))
+	require.NoError(t, err)
+	require.NotNil(t, ch)
+	assert.Equal(t, 5, cap(ch))
+
+	manager.Broadcast("StateA")
+	require.Eventually(t, func() bool {
+		select {
+		case state := <-ch:
+			return assert.Equal(t, "StateA", state)
+		default:
+			return false
+		}
+	}, 100*time.Millisecond, 10*time.Millisecond, "the manager-owned channel should deliver broadcasts")
+
+	// Error paths delegate too.
+	_, err = manager.GetStateChan(nil) //nolint:staticcheck // testing the nil-context guard
+	require.ErrorContains(t, err, "context cannot be nil")
 }

--- a/hooks/broadcast/manager_test.go
+++ b/hooks/broadcast/manager_test.go
@@ -597,3 +597,103 @@ func TestGetStateChan_NilCustomChannelIsManagerOwned(t *testing.T) {
 		t.Fatal("channel was not closed after cancellation; nil custom channel was wrongly treated as external")
 	}
 }
+
+// TestGetStateChan_BackgroundContextSpawnsNoGoroutine verifies that subscribing
+// with a non-cancellable context does not start a per-subscriber cleanup
+// goroutine. Previously every GetStateChan spawned `go func(){ <-ctx.Done(); ...
+// }()`, which for context.Background() parked forever: the goroutine and its map
+// entry leaked for the life of the process.
+func TestGetStateChan_BackgroundContextSpawnsNoGoroutine(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		manager := broadcast.NewManager(newTestLogger().Handler())
+
+		for range 3 {
+			ch, err := manager.GetStateChan(context.Background(), broadcast.WithBufferSize(1))
+			require.NoError(t, err)
+			require.NotNil(t, ch)
+		}
+
+		// On the old code three goroutines are durably blocked on a nil Done()
+		// channel here, and the bubble fails with a deadlock.
+		synctest.Wait()
+
+		manager.UnsubscribeAll()
+	})
+}
+
+// TestUnsubscribeAll_EndsEverySubscriptionEvenWhenBroadcastIsBlocked verifies
+// that UnsubscribeAll releases a parked broadcast and clears every subscriber,
+// closing the manager-owned ones.
+//
+// Parameterised over both blocking delivery modes deliberately. Guaranteed
+// delivery (-1) exercises the path that has always selected on departure; a
+// positive timeout exercises the branch that did not, where UnsubscribeAll
+// could only proceed once the timeout elapsed -- so tearing down a manager
+// blocked for up to the broadcast timeout despite documenting otherwise.
+func TestUnsubscribeAll_EndsEverySubscriptionEvenWhenBroadcastIsBlocked(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name    string
+		timeout time.Duration
+	}{
+		{name: "Guaranteed delivery", timeout: -1},
+		{name: "Long positive timeout", timeout: time.Hour},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				manager := broadcast.NewManager(newTestLogger().Handler())
+
+				blocked := make(chan string, 1)
+				_, err := manager.GetStateChan(
+					context.Background(),
+					broadcast.WithCustomChannel(blocked),
+					broadcast.WithTimeout(tc.timeout),
+				)
+				require.NoError(t, err)
+
+				owned, err := manager.GetStateChan(context.Background(), broadcast.WithBufferSize(1))
+				require.NoError(t, err)
+
+				manager.Broadcast("first")
+
+				broadcastDone := false
+				go func() {
+					manager.Broadcast("second")
+					broadcastDone = true
+				}()
+
+				synctest.Wait()
+				require.False(t, broadcastDone, "broadcast should be parked on the full channel")
+
+				manager.UnsubscribeAll()
+
+				// synctest.Wait returns once every goroutine is durably blocked.
+				// With the fake clock this cannot be satisfied by the timeout
+				// elapsing, so a pass here means departure released the send.
+				synctest.Wait()
+				assert.True(t, broadcastDone, "UnsubscribeAll should release the parked broadcast")
+
+				// Drain any buffered value, then confirm the manager-owned channel closed.
+				for range len(owned) {
+					<-owned
+				}
+				_, open := <-owned
+				assert.False(t, open, "manager-owned channel should be closed by UnsubscribeAll")
+
+				// The caller owns the custom channel, so UnsubscribeAll must leave
+				// it open -- and unsubscribed, so nothing else is delivered to it.
+				require.Len(t, blocked, 1, "the value delivered before the park should still be buffered")
+				assert.Equal(t, "first", <-blocked)
+
+				manager.Broadcast("third")
+				synctest.Wait()
+				assert.Empty(t, blocked, "an unsubscribed channel should receive no further broadcasts")
+
+				close(blocked)
+			})
+		})
+	}
+}

--- a/transitions/config.go
+++ b/transitions/config.go
@@ -158,6 +158,17 @@ func (t *Config) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements json.Unmarshaler interface.
 // It deserializes the config map and rebuilds the internal index.
+//
+// This is the one operation that mutates a Config in place, so it must only be
+// called on a Config that has not yet been shared: not attached to an fsm.Machine
+// and not reachable from another goroutine. Every other method treats a Config as
+// immutable after construction, and fsm.Machine relies on that to read its
+// transition table without holding a lock (see the transitionDB contract in
+// fsm.go). Unmarshaling into a Config that is already in use is a data race and
+// can swap the transition table under a running machine non-atomically.
+//
+// To load transitions into a machine that already exists, unmarshal into a fresh
+// Config and build a new Machine from it.
 func (t *Config) UnmarshalJSON(data []byte) error {
 	var config map[string][]string
 	if err := json.Unmarshal(data, &config); err != nil {


### PR DESCRIPTION
**PR 6 of 8** — splits #80. Stack: #1 → #2 → #3 → #4 → #5 → **#6** → #7 → #8. Base: #85.

**This is the High-severity bug from the review.**

## Problem

`machine.Subscribe(ctx, nil)` wedges the *entire* machine.

A nil channel was never rejected. It fell through to the initial-state send, and a send on a nil channel blocks forever. Because that send happens **while holding the FSM read lock**, every subsequent `Transition`, `SetState` and `MarshalJSON` blocks permanently too — and since an `RWMutex` with a pending writer also blocks new readers, further `Subscribe` calls hang as well. With `context.Background()` there is no recovery at all.

## How this fixes it

Rejects `c == nil` at the top of the method with an error wrapping the pre-existing `fsm.ErrInvalidConfiguration` — **before** any hook is registered, before the broadcast manager is created, and before the read lock is taken. Nothing is registered and no goroutine is spawned.

The guard belongs here rather than in `broadcast.Manager`: the blocking send is on the FSM's own local channel, not on anything the manager returned. `broadcast.Manager` handles a nil custom channel deliberately and safely (it allocates a manager-owned channel), and that behavior is pinned by an existing test.

Also converts the other bare `fmt.Errorf` preconditions (nil context, no callback registry, registry without dynamic hook registration) to wrap `fsm.ErrInvalidConfiguration`, so callers can `errors.Is` them without any new sentinel — the message text is unchanged, so existing assertions keep passing. The `Subscribe` doc comment is corrected while here: it claimed a `hooks.Registry` is required, but any `CallbackExecutor` implementing `HookRegistrar` works.

## Also in this PR

- **Docs:** `transitions.Config.UnmarshalJSON` is the one operation that mutates a `Config` in place. `fsm.Machine` reads its transition table lock-free *because* a `Config` is immutable after construction — so unmarshaling into one already attached to a Machine is a data race. Now documented on the method and cross-referenced from the `transitionDB` contract.
- **Defect fix:** `TestSubscribe_InitialSendRespectsContext` had become a tautology. Once #5 began rejecting already-cancelled contexts up front, the call never reached the initial send its comments described — and it still passed, because the rejection error also wraps `context.Canceled`. Renamed to `TestSubscribe_AlreadyCancelledContextRejected` and rewritten to assert what it actually covers, with `TestSubscribe_InitialSendCancelledMidFlight` added for the genuine mid-flight case.

## Tests

`TestSubscribe_NilChannelRejected` — asserts the error wraps `ErrInvalidConfiguration`, that `reg.GetHooks()` is empty (nothing was registered), that a later `Transition` still works, and that a later valid `Subscribe` succeeds. A second subtest runs in a `synctest` bubble with `context.Background()` to prove no goroutine is spawned.

**Verified red:** without the guard the test hangs permanently at the nil-channel select — the exact deadlock described above.

https://claude.ai/code/session_01WMFFnBa2iXgQ8ZqMjfYREP
