### PR TITLE
fix(fsm): add Machine.Close to release a shared registry's broadcast hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,8 +421,28 @@ _ = machine.Transition(transitions.StatusBooting)
 The `Subscribe()` method:
 - Automatically sets up broadcast management
 - Sends the current state immediately upon subscription
-- Unsubscribes the channel when the context is cancelled
+- Ends the subscription when the context is cancelled
 - Supports multiple concurrent subscribers
+- Accepts each channel only once per machine; subscribing the same channel again returns an error
+
+#### Ending a Subscription
+
+Cancelling the context ends the subscription. The channel is yours: the FSM never
+closes it, and you should not close it while it is still subscribed.
+
+When a `hooks.Registry` outlives the machines using it, call `Close` on a machine
+you are discarding. `Subscribe` registers a per-machine broadcast hook on the
+registry; without `Close` that hook — and its broadcast manager — keeps firing on
+every other machine's transitions for the life of the registry:
+
+```go
+machine, _ := fsm.New(transitions.StatusNew, transitions.Typical,
+	fsm.WithCallbackRegistry(sharedRegistry))
+defer machine.Close() // releases subscribers and removes the broadcast hook
+```
+
+`Close` releases only the subscription plumbing. The machine's state operations
+and any hooks you registered yourself keep working.
 
 Configure broadcast timeout behavior with `fsm.WithBroadcastTimeout()`:
 

--- a/docs/v2-upgrade.md
+++ b/docs/v2-upgrade.md
@@ -167,6 +167,16 @@ machine, err := fsm.New(
 
 ### Step 7: Migrate GetStateChan Usage (Critical)
 
+> **New in v2.6:** `machine.GetStateChan` is renamed to `machine.Subscribe`
+> (same signature; the old name is retained as a deprecated wrapper for
+> compatibility). `machine.Close()` releases every subscriber
+> and removes the machine's broadcast hook from the registry — call it when
+> discarding a machine whose `hooks.Registry` outlives it. Three other behaviours
+> tightened in the same release: subscribing the same channel twice on one
+> machine, subscribing with an already-cancelled context, and passing a nil
+> channel now return errors instead of racing or deadlocking the machine.
+
+
 This changed significantly in v2. The v2 API provides a built-in helper method on the FSM.
 
 #### Decision Guide: Which Broadcasting Pattern Should You Use?
@@ -569,8 +579,9 @@ Use this checklist to verify your migration:
 - [ ] Replaced `fsm.StatusX` with `transitions.StatusX`
 - [ ] Replaced `fsm.TypicalTransitions` with `transitions.Typical`
 - [ ] Updated `fsm.New()` constructor calls (moved handler to options)
-- [ ] Migrated `GetStateChan()` to `machine.Subscribe(ctx, chan)` with hooks.Registry
+- [ ] Migrated `GetStateChan()` to `machine.Subscribe(ctx, chan)` with hooks.Registry (v2.6+; the old name remains as a deprecated wrapper)
 - [ ] Added `WithBroadcastTimeout()` option if custom timeout needed (replaces `WithSyncTimeout`)
+- [ ] Called `machine.Close()` for machines sharing a long-lived `hooks.Registry` (v2.6+)
 - [ ] **Created single abstraction constructor (if architecture supports it)**
 - [ ] Updated all tests
 - [ ] Verified with `go build ./...`

--- a/errors.go
+++ b/errors.go
@@ -35,3 +35,7 @@ var ErrEmptyTransitions = errors.New("transitions cannot be empty")
 
 // ErrInvalidJSONTransitions is returned when JSON transitions configuration is invalid
 var ErrInvalidJSONTransitions = errors.New("invalid transitions in JSON")
+
+// ErrMachineClosed is returned when Subscribe is called on a Machine whose
+// broadcast plumbing has been released by Close
+var ErrMachineClosed = errors.New("machine is closed")

--- a/fsm.go
+++ b/fsm.go
@@ -37,6 +37,7 @@ package fsm
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"slices"
@@ -85,11 +86,16 @@ type Machine struct {
 	id uint64
 
 	// subMu gates the lazily-created broadcast plumbing below. It is separate
-	// from mutex on purpose: the setup it guards runs before Subscribe takes the
-	// FSM lock, and it is never held while mutex is acquired.
-	subMu            sync.Mutex
+	// from mutex on purpose: a broadcast runs from a post-transition hook while
+	// mutex is held for writing, so Close must never take mutex -- it has to be
+	// able to reach the broadcast manager to release exactly that broadcast.
+	//
+	// Nested lock order: mutex -> subMu. Never acquire mutex while holding subMu.
+	subMu            sync.RWMutex
 	broadcastManager *broadcast.Manager
 	hookName         string
+	closed           bool
+	closeErr         error
 }
 
 // machineIDCounter stamps each Machine with a process-unique id. A pointer
@@ -393,17 +399,27 @@ func (fsm *Machine) transition(ctx context.Context, toState string) error {
 // ErrInvalidConfiguration. Subscribing a channel that is already subscribed returns
 // an error while the first subscription is live.
 //
-// The channel will automatically receive all future state transitions until the context
-// is cancelled, at which point it is automatically unsubscribed from receiving further broadcasts.
-// The channel is NOT closed; the caller maintains ownership and is responsible for channel lifecycle.
+// The channel receives all future state transitions until the context is cancelled, or
+// the Machine is closed with Close — whichever comes first. The channel is NOT closed;
+// the caller maintains ownership and is responsible for its lifecycle, and must not
+// close it while it is still subscribed.
+//
+// Passing a non-cancellable context (context.Background()) is supported, but then Close
+// is the only way to end the subscription: a subscriber that is simply dropped stays
+// registered for the life of the Machine. Prefer a cancellable context.
 //
 // Subscribe can be called multiple times with different channels and contexts. All channels
 // share the same broadcast manager, which is lazily initialized only once upon the first call.
+// A channel may hold only one live subscription per Machine; subscribing the same channel twice
+// returns an error. Re-subscribing a channel whose previous subscription has ended is allowed,
+// as is subscribing one channel to several Machines.
+// An already-cancelled context is rejected.
 //
 // Each Machine registers its broadcast hook under a name unique to that Machine, so a single
 // hooks.Registry may be shared across Machines without Subscribe failing. Note, however, that
-// hooks registered on a shared registry fire for every Machine's transitions; prefer one registry
-// per Machine unless that shared behavior is intended.
+// hooks registered on a shared registry fire for every Machine's transitions. When sharing a
+// registry, call Close on a Machine you are discarding, or its broadcast hook keeps firing on
+// every other Machine's transitions for the life of the registry.
 //
 // Broadcast delivery behavior is controlled by the timeout configured via WithBroadcastTimeout:
 //   - timeout = 0: best-effort delivery (non-blocking, drops if channel is full)
@@ -474,8 +490,7 @@ func (fsm *Machine) Subscribe(ctx context.Context, c chan string) error {
 		)
 	}
 
-	manager, err := fsm.ensureBroadcast(registrar)
-	if err != nil {
+	if _, err := fsm.ensureBroadcast(registrar); err != nil {
 		return err
 	}
 
@@ -490,11 +505,24 @@ func (fsm *Machine) Subscribe(ctx context.Context, c chan string) error {
 	fsm.mutex.RLock()
 	defer fsm.mutex.RUnlock()
 
-	if _, err := manager.GetStateChan(
+	// subMu is held for reading across registration and the initial send so a
+	// concurrent Close cannot detach the manager underneath us and leave this
+	// subscriber permanently silent. Close takes it for writing, so it waits for
+	// subscriptions already in flight and blocks new ones. Both are read locks
+	// here, so concurrent Subscribe callers still proceed in parallel.
+	fsm.subMu.RLock()
+	defer fsm.subMu.RUnlock()
+
+	if fsm.closed {
+		return ErrMachineClosed
+	}
+
+	_, err := fsm.broadcastManager.GetStateChan(
 		ctx,
 		broadcast.WithCustomChannel(c),
 		broadcast.WithTimeout(fsm.broadcastTimeout),
-	); err != nil {
+	)
+	if err != nil {
 		return fmt.Errorf("failed to register channel: %w", err)
 	}
 
@@ -523,16 +551,20 @@ func (fsm *Machine) GetStateChan(ctx context.Context, c chan string) error {
 // ensureBroadcast lazily creates this Machine's broadcast manager and registers
 // its post-transition broadcast hook, returning the manager.
 //
-// It replaces a sync.Once, which cached a transient setup failure forever: a
-// Once cannot be undone, so one failed registration made every later Subscribe
-// on that Machine replay the same error with no way to recover. A failed setup
-// is no longer cached -- the next call retries.
+// It replaces a sync.Once, which Close made untenable: a Once cannot be undone,
+// reading the manager it writes from a goroutine that never called Do would be a
+// data race, and a cached setup error permanently poisoned the Machine. A failed
+// setup is no longer cached -- the next call retries.
 //
-// subMu is released before returning, so it is never held while acquiring
-// fsm.mutex and cannot deadlock against an in-flight transition.
+// subMu is released before returning, so this never holds it while acquiring
+// fsm.mutex and therefore does not participate in the mutex -> subMu order.
 func (fsm *Machine) ensureBroadcast(registrar HookRegistrar) (*broadcast.Manager, error) {
 	fsm.subMu.Lock()
 	defer fsm.subMu.Unlock()
+
+	if fsm.closed {
+		return nil, ErrMachineClosed
+	}
 
 	if fsm.broadcastManager != nil {
 		return fsm.broadcastManager, nil
@@ -556,4 +588,76 @@ func (fsm *Machine) ensureBroadcast(registrar HookRegistrar) (*broadcast.Manager
 	fsm.hookName = name
 
 	return manager, nil
+}
+
+// Close releases only the state-subscription resources this Machine created:
+// it ends every live Subscribe subscription and removes the broadcast hook
+// that Subscribe registered on the callback registry. It does NOT stop the
+// Machine -- GetState, Transition, SetState, MarshalJSON, and every hook the
+// caller registered themselves keep working exactly as before.
+//
+// Call it when discarding a Machine whose hooks.Registry outlives it (a shared
+// registry). Otherwise that hook, and the broadcast manager behind it, keep
+// firing on every transition of every other Machine using that registry.
+//
+// Channels supplied to Subscribe are owned by the caller and are not closed;
+// their subscribers see silence, exactly as when their context is cancelled.
+// After Close, Subscribe returns ErrMachineClosed.
+//
+// Close is idempotent, but it does not forget a failure: if removing the hook
+// fails, every subsequent call returns that same error, because a silently
+// orphaned hook is the exact condition Close exists to prevent.
+//
+// If the CallbackExecutor also provides RemoveHook(name string) error
+// (hooks.Registry does), Close removes the machine's broadcast hook; otherwise
+// the hook stays registered and Close returns an error naming it.
+//
+// Close blocks while an in-flight broadcast completes, and can block for as long
+// as a concurrent Subscribe holds the subscription gate -- which, with an
+// unbuffered channel and a non-cancellable context, may be indefinitely. Calling
+// it from a transition hook avoids the lock cycle: Close never takes the FSM
+// mutex, and hook executors release the registry lock before running hooks.
+// Hooks run in sequence, though, so if this machine's own broadcast hook earlier
+// in the same synchronous hook chain is parked in a blocking (negative-timeout)
+// send, a later hook calling Close is not reached until that send completes.
+func (fsm *Machine) Close() error {
+	fsm.subMu.Lock()
+	defer fsm.subMu.Unlock()
+
+	if fsm.closed {
+		return fsm.closeErr
+	}
+	fsm.closed = true
+
+	manager, hookName := fsm.broadcastManager, fsm.hookName
+	if manager == nil {
+		// Subscribe was never called: nothing was ever registered.
+		return nil
+	}
+
+	// Release subscribers first. UnsubscribeAll signals every subscription
+	// before taking the manager mutex, so it cannot be blocked by the very
+	// broadcast it is trying to free.
+	manager.UnsubscribeAll()
+	fsm.broadcastManager = nil
+	fsm.hookName = ""
+
+	remover, ok := fsm.callbacks.(interface{ RemoveHook(name string) error })
+	if !ok {
+		// Still closed and still unsubscribed: a partial failure must not leave
+		// the Machine half-open. Name the hook so it can be removed by hand.
+		fsm.closeErr = fmt.Errorf(
+			"%w: callback registry does not support removing hooks; hook %q is orphaned",
+			ErrInvalidConfiguration, hookName,
+		)
+		return fsm.closeErr
+	}
+
+	// A hook the caller already removed is not an error.
+	if err := remover.RemoveHook(hookName); err != nil && !errors.Is(err, hooks.ErrHookNotFound) {
+		fsm.closeErr = fmt.Errorf("failed to remove broadcast hook %q: %w", hookName, err)
+		return fsm.closeErr
+	}
+
+	return nil
 }

--- a/fsm_test.go
+++ b/fsm_test.go
@@ -2,6 +2,7 @@ package fsm
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -932,8 +933,8 @@ func TestSubscribe_SharedRegistry(t *testing.T) {
 
 	ch1 := make(chan string, 10)
 	ch2 := make(chan string, 10)
-	require.NoError(t, m1.Subscribe(ctx, ch1))
-	require.NoError(t, m2.Subscribe(ctx, ch2)) // previously failed permanently
+	mustSubscribe(t, m1, ctx, ch1)
+	mustSubscribe(t, m2, ctx, ch2) // previously failed permanently
 
 	// Each subscriber receives its own machine's initial state.
 	assert.Equal(t, transitions.StatusNew, <-ch1)
@@ -980,7 +981,7 @@ func TestSubscribe_InitialSendIsAtomic(t *testing.T) {
 	for i := range 500 {
 		ctx, cancel := context.WithCancel(context.Background())
 		ch := make(chan string, 256)
-		require.NoError(t, machine.Subscribe(ctx, ch))
+		mustSubscribe(t, machine, ctx, ch)
 
 		// Collect the initial value plus the first broadcast.
 		var got []string
@@ -1029,32 +1030,6 @@ func TestSubscribe_AlreadyCancelledContextRejected(t *testing.T) {
 	// Rejected before registration: the channel is free to subscribe under a
 	// live context, which a lingering entry would refuse as a duplicate.
 	require.NoError(t, machine.Subscribe(t.Context(), ch))
-}
-
-// TestGetStateChan_DeprecatedAliasDelegatesToSubscribe verifies that the
-// deprecated wrapper still works and behaves identically to Subscribe, so
-// callers on the old name keep working.
-func TestGetStateChan_DeprecatedAliasDelegatesToSubscribe(t *testing.T) {
-	t.Parallel()
-
-	reg, err := hooks.NewRegistry(hooks.WithTransitions(transitions.Typical))
-	require.NoError(t, err)
-	machine, err := New(transitions.StatusNew, transitions.Typical, WithCallbackRegistry(reg))
-	require.NoError(t, err)
-
-	ch := make(chan string, 10)
-	require.NoError(t, machine.GetStateChan(t.Context(), ch))
-	assert.Equal(t, transitions.StatusNew, <-ch)
-
-	require.NoError(t, machine.Transition(transitions.StatusBooting))
-	require.Eventually(t, func() bool {
-		select {
-		case state := <-ch:
-			return assert.Equal(t, transitions.StatusBooting, state)
-		default:
-			return false
-		}
-	}, 100*time.Millisecond, 10*time.Millisecond, "the deprecated alias should deliver transitions")
 }
 
 func TestFSM_IsTransitionAllowed(t *testing.T) {
@@ -1174,44 +1149,22 @@ func TestSubscribe_NilChannelRejected(t *testing.T) {
 	})
 }
 
-// TestSubscribe_InitialSendCancelledMidFlight covers the initial-send
-// cancellation path. Its sibling, TestSubscribe_AlreadyCancelledContextRejected,
-// pre-cancels the context and so is rejected by the broadcast manager before the
-// send is ever reached; this exercises a cancellation that lands while the
-// send is genuinely blocked on a full channel.
-func TestSubscribe_InitialSendCancelledMidFlight(t *testing.T) {
-	t.Parallel()
+// mockHookRegistrar implements HookRegistrar but deliberately has no RemoveHook
+// method, to exercise Close against a callback executor that cannot remove hooks.
+type mockHookRegistrar struct {
+	*mockCallbackExecutor
+}
 
-	synctest.Test(t, func(t *testing.T) {
-		reg, err := hooks.NewRegistry(hooks.WithTransitions(transitions.Typical))
-		require.NoError(t, err)
-		machine, err := New(transitions.StatusNew, transitions.Typical, WithCallbackRegistry(reg))
-		require.NoError(t, err)
+func newMockHookRegistrar() *mockHookRegistrar {
+	return &mockHookRegistrar{mockCallbackExecutor: newMockCallbackExecutor()}
+}
 
-		ctx, cancel := context.WithCancel(t.Context())
-		ch := make(chan string) // unbuffered, no reader: the initial send blocks
+func (m *mockHookRegistrar) RegisterPostTransitionHook(hooks.PostTransitionHookConfig) error {
+	return nil
+}
 
-		var subErr error
-		done := make(chan struct{})
-		go func() {
-			subErr = machine.Subscribe(ctx, ch)
-			close(done)
-		}()
-
-		// Let the subscription reach the blocked send before cancelling.
-		synctest.Wait()
-		select {
-		case <-done:
-			t.Fatal("Subscribe returned before the initial send could block")
-		default:
-		}
-
-		cancel()
-		synctest.Wait()
-
-		<-done
-		require.ErrorIs(t, subErr, context.Canceled)
-	})
+func (m *mockHookRegistrar) RegisterPreTransitionHook(hooks.PreTransitionHookConfig) error {
+	return nil
 }
 
 // broadcastHookNames returns the names of the broadcast hooks Subscribe has
@@ -1254,6 +1207,251 @@ func TestSubscribe_HookNamesAreUniquePerMachine(t *testing.T) {
 	assert.Equal(t, fmt.Sprintf("fsm.Subscribe.%d", m1.id), m1.hookName)
 }
 
+// TestMachineClose_RemovesHookFromSharedRegistry verifies the core of the fix:
+// a Machine discarded from a shared registry can release its broadcast hook, so
+// it stops firing on every other Machine's transitions.
+func TestMachineClose_RemovesHookFromSharedRegistry(t *testing.T) {
+	t.Parallel()
+
+	reg, err := hooks.NewRegistry(hooks.WithTransitions(transitions.Typical))
+	require.NoError(t, err)
+
+	m1, err := New(transitions.StatusNew, transitions.Typical, WithCallbackRegistry(reg))
+	require.NoError(t, err)
+	m2, err := New(transitions.StatusNew, transitions.Typical, WithCallbackRegistry(reg))
+	require.NoError(t, err)
+
+	ch1 := make(chan string, 10)
+	ch2 := make(chan string, 10)
+	mustSubscribe(t, m1, t.Context(), ch1)
+	mustSubscribe(t, m2, t.Context(), ch2)
+	assert.Equal(t, transitions.StatusNew, <-ch1)
+	assert.Equal(t, transitions.StatusNew, <-ch2)
+
+	require.Len(t, broadcastHookNames(t, reg), 2)
+
+	m2Hook := m2.hookName
+	require.NoError(t, m1.Close())
+
+	// Only m2's hook survives.
+	assert.Equal(t, []string{m2Hook}, broadcastHookNames(t, reg))
+
+	// m1 still transitions, but no longer broadcasts.
+	require.NoError(t, m1.Transition(transitions.StatusBooting))
+	require.Never(t, func() bool {
+		select {
+		case <-ch1:
+			return true
+		default:
+			return false
+		}
+	}, 100*time.Millisecond, 10*time.Millisecond, "closed machine must not broadcast")
+
+	// m2 is unaffected.
+	require.NoError(t, m2.Transition(transitions.StatusBooting))
+	require.Eventually(t, func() bool {
+		select {
+		case state := <-ch2:
+			return assert.Equal(t, transitions.StatusBooting, state)
+		default:
+			return false
+		}
+	}, 100*time.Millisecond, 10*time.Millisecond, "the surviving machine must still broadcast")
+}
+
+// TestMachineClose_Idempotent verifies repeated Close calls are safe.
+func TestMachineClose_Idempotent(t *testing.T) {
+	t.Parallel()
+
+	reg, err := hooks.NewRegistry(hooks.WithTransitions(transitions.Typical))
+	require.NoError(t, err)
+	machine, err := New(transitions.StatusNew, transitions.Typical, WithCallbackRegistry(reg))
+	require.NoError(t, err)
+
+	mustSubscribe(t, machine, t.Context(), make(chan string, 1))
+	require.NoError(t, machine.Close())
+	require.NoError(t, machine.Close())
+	assert.Empty(t, broadcastHookNames(t, reg))
+}
+
+// TestMachineClose_BeforeSubscribe verifies Close on a Machine that never
+// subscribed, and that Subscribe is refused afterwards.
+func TestMachineClose_BeforeSubscribe(t *testing.T) {
+	t.Parallel()
+
+	reg, err := hooks.NewRegistry(hooks.WithTransitions(transitions.Typical))
+	require.NoError(t, err)
+	machine, err := New(transitions.StatusNew, transitions.Typical, WithCallbackRegistry(reg))
+	require.NoError(t, err)
+
+	require.NoError(t, machine.Close())
+	assert.Empty(t, reg.GetHooks())
+
+	require.ErrorIs(t, machine.Subscribe(t.Context(), make(chan string, 1)), ErrMachineClosed)
+}
+
+// TestMachineClose_MachineStaysUsable verifies that Close releases only the
+// subscription plumbing: state operations and caller-registered hooks continue
+// to work.
+func TestMachineClose_MachineStaysUsable(t *testing.T) {
+	t.Parallel()
+
+	reg, err := hooks.NewRegistry(hooks.WithTransitions(transitions.Typical))
+	require.NoError(t, err)
+
+	userHookCalls := 0
+	require.NoError(t, reg.RegisterPostTransitionHook(hooks.PostTransitionHookConfig{
+		Name: "user-hook",
+		From: []string{"*"},
+		To:   []string{"*"},
+		Action: func(ctx context.Context, from, to string) {
+			userHookCalls++
+		},
+	}))
+
+	machine, err := New(transitions.StatusNew, transitions.Typical, WithCallbackRegistry(reg))
+	require.NoError(t, err)
+	mustSubscribe(t, machine, t.Context(), make(chan string, 1))
+	require.NoError(t, machine.Close())
+
+	require.NoError(t, machine.Transition(transitions.StatusBooting))
+	assert.Equal(t, transitions.StatusBooting, machine.GetState())
+	require.NoError(t, machine.SetState(transitions.StatusRunning))
+	assert.Equal(t, transitions.StatusRunning, machine.GetState())
+	assert.Equal(t, 2, userHookCalls, "caller-registered hooks must still fire after Close")
+
+	// The caller's own hook is untouched by Close.
+	assert.Len(t, reg.GetHooks(), 1)
+}
+
+// TestMachineClose_RegistrarWithoutRemoveHook verifies that a callback executor
+// which cannot remove hooks produces an error naming the orphaned hook, while
+// still marking the machine closed and releasing its subscribers.
+func TestMachineClose_RegistrarWithoutRemoveHook(t *testing.T) {
+	t.Parallel()
+
+	registrar := newMockHookRegistrar()
+	mockDB := newMockTransitionDB(map[string][]string{
+		"state1": {"state2"},
+		"state2": {},
+	})
+
+	machine, err := New("state1", mockDB, WithCallbackRegistry(registrar))
+	require.NoError(t, err)
+
+	ch := make(chan string, 1)
+	mustSubscribe(t, machine, t.Context(), ch)
+
+	hookName := machine.hookName // Close clears it, so capture it first
+
+	err = machine.Close()
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrInvalidConfiguration)
+	assert.Contains(t, err.Error(), hookName, "the orphaned hook must be named so it can be removed by hand")
+
+	// Closed regardless of the failure, and the error is remembered.
+	require.ErrorIs(t, machine.Subscribe(t.Context(), make(chan string, 1)), ErrMachineClosed)
+	assert.Equal(t, err.Error(), machine.Close().Error(), "the teardown error must be cached, not forgotten")
+}
+
+// TestSubscribe_CancellationStopsDelivery verifies that cancelling the
+// subscription's context stops delivery and frees the channel for re-use. This
+// is the only per-subscription teardown path: the caller owns the channel, and
+// scopes its lifetime with the context it subscribed under.
+//
+// Runs in a synctest bubble so the assertion of silence is deterministic:
+// teardown happens on a context.AfterFunc goroutine, and synctest.Wait blocks
+// until it has finished rather than guessing at a timeout.
+func TestSubscribe_CancellationStopsDelivery(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		reg, err := hooks.NewRegistry(hooks.WithTransitions(transitions.Typical))
+		require.NoError(t, err)
+		machine, err := New(transitions.StatusNew, transitions.Typical, WithCallbackRegistry(reg))
+		require.NoError(t, err)
+
+		ctx, cancel := context.WithCancel(t.Context())
+		ch := make(chan string, 10)
+		mustSubscribe(t, machine, ctx, ch)
+		assert.Equal(t, transitions.StatusNew, <-ch)
+
+		require.NoError(t, machine.Transition(transitions.StatusBooting))
+		synctest.Wait()
+		assert.Equal(t, transitions.StatusBooting, <-ch)
+
+		cancel()
+		synctest.Wait() // the AfterFunc teardown has now completed
+
+		require.NoError(t, machine.Transition(transitions.StatusRunning))
+		synctest.Wait()
+		select {
+		case state := <-ch:
+			t.Fatalf("cancelled subscriber still received %q", state)
+		default:
+		}
+
+		// The channel is free to subscribe again under a fresh context.
+		mustSubscribe(t, machine, t.Context(), ch)
+		assert.Equal(t, transitions.StatusRunning, <-ch)
+
+		require.NoError(t, machine.Close())
+	})
+}
+
+// TestSubscribe_DuplicateChannelRejectedOnMachine verifies that the
+// duplicate-subscription sentinel propagates through Machine.Subscribe.
+func TestSubscribe_DuplicateChannelRejectedOnMachine(t *testing.T) {
+	t.Parallel()
+
+	reg, err := hooks.NewRegistry(hooks.WithTransitions(transitions.Typical))
+	require.NoError(t, err)
+	machine, err := New(transitions.StatusNew, transitions.Typical, WithCallbackRegistry(reg))
+	require.NoError(t, err)
+
+	ch := make(chan string, 10)
+	mustSubscribe(t, machine, t.Context(), ch)
+	assert.Equal(t, transitions.StatusNew, <-ch)
+
+	require.ErrorContains(t, machine.Subscribe(t.Context(), ch), "already subscribed")
+
+	// The first subscription is still live, and receives exactly one copy.
+	require.NoError(t, machine.Transition(transitions.StatusBooting))
+	require.Eventually(t, func() bool {
+		select {
+		case state := <-ch:
+			return assert.Equal(t, transitions.StatusBooting, state)
+		default:
+			return false
+		}
+	}, 100*time.Millisecond, 10*time.Millisecond, "the original subscription should still be live")
+	assert.Empty(t, ch, "state should be delivered exactly once")
+}
+
+// TestSubscribe_SameChannelOnTwoMachinesAllowed verifies that the
+// duplicate-subscription rule is per-Machine, not global.
+func TestSubscribe_SameChannelOnTwoMachinesAllowed(t *testing.T) {
+	t.Parallel()
+
+	reg1, err := hooks.NewRegistry(hooks.WithTransitions(transitions.Typical))
+	require.NoError(t, err)
+	reg2, err := hooks.NewRegistry(hooks.WithTransitions(transitions.Typical))
+	require.NoError(t, err)
+
+	m1, err := New(transitions.StatusNew, transitions.Typical, WithCallbackRegistry(reg1))
+	require.NoError(t, err)
+	m2, err := New(transitions.StatusNew, transitions.Typical, WithCallbackRegistry(reg2))
+	require.NoError(t, err)
+
+	ch := make(chan string, 10)
+	mustSubscribe(t, m1, t.Context(), ch)
+	mustSubscribe(t, m2, t.Context(), ch)
+
+	// Both initial states arrive on the shared channel.
+	assert.Equal(t, transitions.StatusNew, <-ch)
+	assert.Equal(t, transitions.StatusNew, <-ch)
+}
+
 // TestSubscribe_RetriesAfterFailedSetup verifies that a failed hook
 // registration is no longer cached permanently. The sync.Once this replaced
 // stored the error forever, so one transient failure poisoned the machine.
@@ -1281,4 +1479,231 @@ func TestSubscribe_RetriesAfterFailedSetup(t *testing.T) {
 	good, err := New(transitions.StatusNew, transitions.Typical, WithCallbackRegistry(goodReg))
 	require.NoError(t, err)
 	mustSubscribe(t, good, t.Context(), make(chan string, 1))
+}
+
+// TestMachineClose_ConcurrentCalls verifies that concurrent Close calls agree on
+// one outcome and remove the hook exactly once.
+func TestMachineClose_ConcurrentCalls(t *testing.T) {
+	t.Parallel()
+
+	reg, err := hooks.NewRegistry(hooks.WithTransitions(transitions.Typical))
+	require.NoError(t, err)
+	machine, err := New(transitions.StatusNew, transitions.Typical, WithCallbackRegistry(reg))
+	require.NoError(t, err)
+	mustSubscribe(t, machine, t.Context(), make(chan string, 1))
+
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Go(func() {
+			if err := machine.Close(); err != nil {
+				t.Errorf("concurrent Close returned an error: %v", err)
+			}
+		})
+	}
+	wg.Wait()
+
+	assert.Empty(t, broadcastHookNames(t, reg))
+}
+
+// TestMachineClose_RacingSubscribe verifies that Close and Subscribe
+// cannot interleave into a subscriber attached to a manager Close has already
+// detached. Either Subscribe wins and its subscription is then released by
+// Close, or Close wins and Subscribe is refused.
+func TestMachineClose_RacingSubscribe(t *testing.T) {
+	t.Parallel()
+
+	for range 200 {
+		reg, err := hooks.NewRegistry(hooks.WithTransitions(transitions.Typical))
+		require.NoError(t, err)
+		machine, err := New(transitions.StatusNew, transitions.Typical, WithCallbackRegistry(reg))
+		require.NoError(t, err)
+
+		ch := make(chan string, 1)
+
+		var wg sync.WaitGroup
+		var subErr error
+		wg.Go(func() { subErr = machine.Subscribe(context.Background(), ch) })
+		wg.Go(func() {
+			// The racing Close may legitimately be the first or second caller;
+			// either way it must not error.
+			if err := machine.Close(); err != nil {
+				t.Errorf("racing Close returned an error: %v", err)
+			}
+		})
+		wg.Wait()
+
+		if subErr != nil {
+			require.ErrorIs(t, subErr, ErrMachineClosed)
+		}
+		// Either way the machine ends up closed with no lingering hook.
+		require.NoError(t, machine.Close())
+		assert.Empty(t, broadcastHookNames(t, reg))
+	}
+}
+
+// TestMachineClose_FromWithinAHook verifies the documented guarantee that Close
+// is safe to call from a transition hook: it never takes the FSM mutex, and the
+// hook executors release the registry lock before running hooks.
+func TestMachineClose_FromWithinAHook(t *testing.T) {
+	t.Parallel()
+
+	reg, err := hooks.NewRegistry(hooks.WithTransitions(transitions.Typical))
+	require.NoError(t, err)
+
+	var machine *Machine
+	closeErr := make(chan error, 1)
+	require.NoError(t, reg.RegisterPostTransitionHook(hooks.PostTransitionHookConfig{
+		Name: "closer",
+		From: []string{"*"},
+		To:   []string{transitions.StatusBooting},
+		Action: func(ctx context.Context, from, to string) {
+			closeErr <- machine.Close()
+		},
+	}))
+
+	machine, err = New(transitions.StatusNew, transitions.Typical, WithCallbackRegistry(reg))
+	require.NoError(t, err)
+	mustSubscribe(t, machine, t.Context(), make(chan string, 10))
+
+	// Must not deadlock.
+	require.NoError(t, machine.Transition(transitions.StatusBooting))
+	require.NoError(t, <-closeErr)
+
+	assert.Empty(t, broadcastHookNames(t, reg))
+	// The machine remains usable for state operations.
+	require.NoError(t, machine.Transition(transitions.StatusRunning))
+}
+
+// TestSubscribe_InitialSendCancelledMidFlight covers the initial-send
+// cancellation path. Its sibling, TestSubscribe_AlreadyCancelledContextRejected,
+// pre-cancels the context and so is rejected by the broadcast manager before the
+// send is ever reached; this exercises a cancellation that lands while the
+// send is genuinely blocked on a full channel.
+func TestSubscribe_InitialSendCancelledMidFlight(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		reg, err := hooks.NewRegistry(hooks.WithTransitions(transitions.Typical))
+		require.NoError(t, err)
+		machine, err := New(transitions.StatusNew, transitions.Typical, WithCallbackRegistry(reg))
+		require.NoError(t, err)
+
+		ctx, cancel := context.WithCancel(t.Context())
+		ch := make(chan string) // unbuffered, no reader: the initial send blocks
+
+		var subErr error
+		done := make(chan struct{})
+		go func() {
+			subErr = machine.Subscribe(ctx, ch)
+			close(done)
+		}()
+
+		// Let the subscription reach the blocked send before cancelling.
+		synctest.Wait()
+		select {
+		case <-done:
+			t.Fatal("Subscribe returned before the initial send could block")
+		default:
+		}
+
+		cancel()
+		synctest.Wait()
+
+		<-done
+		require.ErrorIs(t, subErr, context.Canceled)
+	})
+}
+
+// mockFailingRemover implements HookRegistrar and provides a RemoveHook method
+// that always fails, to cover Close's hook-removal error path.
+type mockFailingRemover struct {
+	*mockCallbackExecutor
+	removeErr error
+}
+
+func (m *mockFailingRemover) RegisterPostTransitionHook(hooks.PostTransitionHookConfig) error {
+	return nil
+}
+
+func (m *mockFailingRemover) RegisterPreTransitionHook(hooks.PreTransitionHookConfig) error {
+	return nil
+}
+
+func (m *mockFailingRemover) RemoveHook(string) error { return m.removeErr }
+
+// TestMachineClose_HookRemovalFails verifies that a registry which accepts the
+// hook but fails to remove it surfaces the failure, names the orphaned hook, and
+// still leaves the machine closed rather than half-open.
+func TestMachineClose_HookRemovalFails(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("registry exploded")
+	registrar := &mockFailingRemover{
+		mockCallbackExecutor: newMockCallbackExecutor(),
+		removeErr:            sentinel,
+	}
+	mockDB := newMockTransitionDB(map[string][]string{
+		"state1": {"state2"},
+		"state2": {},
+	})
+
+	machine, err := New("state1", mockDB, WithCallbackRegistry(registrar))
+	require.NoError(t, err)
+	mustSubscribe(t, machine, t.Context(), make(chan string, 1))
+
+	hookName := machine.hookName
+
+	err = machine.Close()
+	require.ErrorIs(t, err, sentinel)
+	assert.Contains(t, err.Error(), hookName)
+
+	// Closed despite the failure, and the error is remembered rather than
+	// silently forgotten on the next call.
+	require.ErrorIs(t, machine.Subscribe(t.Context(), make(chan string, 1)), ErrMachineClosed)
+	require.ErrorIs(t, machine.Close(), sentinel)
+}
+
+// TestMachineClose_ToleratesAlreadyRemovedHook verifies that a hook the caller
+// removed themselves is not treated as a Close failure.
+func TestMachineClose_ToleratesAlreadyRemovedHook(t *testing.T) {
+	t.Parallel()
+
+	reg, err := hooks.NewRegistry(hooks.WithTransitions(transitions.Typical))
+	require.NoError(t, err)
+	machine, err := New(transitions.StatusNew, transitions.Typical, WithCallbackRegistry(reg))
+	require.NoError(t, err)
+	mustSubscribe(t, machine, t.Context(), make(chan string, 1))
+
+	require.NoError(t, reg.RemoveHook(machine.hookName))
+	require.NoError(t, machine.Close(), "a hook already removed by the caller is not a Close failure")
+}
+
+// TestGetStateChan_DeprecatedAliasDelegatesToSubscribe verifies that the
+// deprecated wrapper still works and behaves identically to Subscribe, so
+// callers on the old name keep working.
+func TestGetStateChan_DeprecatedAliasDelegatesToSubscribe(t *testing.T) {
+	t.Parallel()
+
+	reg, err := hooks.NewRegistry(hooks.WithTransitions(transitions.Typical))
+	require.NoError(t, err)
+	machine, err := New(transitions.StatusNew, transitions.Typical, WithCallbackRegistry(reg))
+	require.NoError(t, err)
+
+	ch := make(chan string, 10)
+	require.NoError(t, machine.GetStateChan(t.Context(), ch))
+	assert.Equal(t, transitions.StatusNew, <-ch)
+
+	require.NoError(t, machine.Transition(transitions.StatusBooting))
+	require.Eventually(t, func() bool {
+		select {
+		case state := <-ch:
+			return assert.Equal(t, transitions.StatusBooting, state)
+		default:
+			return false
+		}
+	}, 100*time.Millisecond, 10*time.Millisecond, "the deprecated alias should deliver transitions")
+
+	// Error paths delegate too.
+	require.ErrorIs(t, machine.GetStateChan(t.Context(), nil), ErrInvalidConfiguration)
+	require.ErrorContains(t, machine.GetStateChan(t.Context(), ch), "already subscribed")
 }

--- a/readme_test.go
+++ b/readme_test.go
@@ -361,6 +361,42 @@ func TestReadme_SubscribingToStateChanges(t *testing.T) {
 	})
 }
 
+// TestReadme_EndingASubscription tests the "Ending a Subscription" example from
+// README.md: cancelling the context ends the subscription, and Close releases a
+// machine that shares a registry.
+func TestReadme_EndingASubscription(t *testing.T) {
+	t.Parallel()
+
+	sharedRegistry, err := hooks.NewRegistry(
+		hooks.WithLogHandler(slog.Default().Handler()),
+		hooks.WithTransitions(transitions.Typical),
+	)
+	require.NoError(t, err)
+
+	machine, err := New(
+		transitions.StatusNew,
+		transitions.Typical,
+		WithCallbackRegistry(sharedRegistry),
+	)
+	require.NoError(t, err)
+	defer func() {
+		// README: defer machine.Close()
+		require.NoError(t, machine.Close())
+	}()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	stateChan := make(chan string, 10)
+	mustSubscribe(t, machine, ctx, stateChan)
+	assert.Equal(t, transitions.StatusNew, <-stateChan)
+
+	// README: cancelling the context ends the subscription.
+	cancel()
+
+	// The machine keeps working afterwards.
+	require.NoError(t, machine.Transition(transitions.StatusBooting))
+	assert.Equal(t, transitions.StatusBooting, machine.GetState())
+}
+
 // TestReadme_StateTransitionOperations tests state transition examples from README.md
 func TestReadme_StateTransitionOperations(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
**PR 8 of 8** — the last of the split of #80. Stack: #1 → #2 → #3 → #4 → #5 → #6 → #7 → **#8**. Base: #87.

## Problem

`Subscribe` registers a per-machine broadcast hook on the callback registry, and there was **no way to remove it**. On a long-lived shared `hooks.Registry`, every discarded `Machine` leaves that hook — and its `broadcast.Manager` — behind, firing on every transition of every *other* machine, for the life of the registry. There was no remedy at any price.

## How this fixes it

Adds `Machine.Close`, which releases every live subscriber via `UnsubscribeAll` (#84) and removes the hook if the `CallbackExecutor` also provides `RemoveHook(name string) error` — which `hooks.Registry` does. The check is a structural type assertion on an anonymous interface, so **no new exported interface** is introduced, and `HookRegistrar` is deliberately left untouched: adding a method to that shipped interface would break every third-party implementation. A `CallbackExecutor` without `RemoveHook` makes `Close` return an error *naming the orphaned hook* so it can be removed by hand.

**`Close` releases only the subscription plumbing.** `GetState`, `Transition`, `SetState`, `MarshalJSON` and every caller-registered hook keep working. Making `Transition` fail after `Close` would mean a closed-check in every method — a much larger semantic change, and not what "release the subscription resources" means.

It is idempotent, but **not amnesiac**: a failed hook removal is cached and returned by every later call. Returning `nil` after a failure would hide a permanently orphaned hook, which is the exact condition `Close` exists to prevent.

### Why the setup gate widens to an `RWMutex`

`Close` must be able to detach the broadcast manager. A plain mutex released after setup lets `Close` interleave with an in-flight `Subscribe` — detaching the manager underneath it and leaving a **permanently silent subscriber**. `Subscribe` now holds the gate for *reading* across registration and the initial send; `Close` takes it for writing.

Lock order is `mutex → subMu`, and `Close` must **never** take `mutex`: a transition may hold it while blocked inside `Broadcast`, and `Close` needs to reach `UnsubscribeAll` to release exactly that broadcast. Verified: removing the gate produces a `DATA RACE` on `broadcastManager`.

## Tests

`TestMachineClose_RemovesHookFromSharedRegistry` is the core proof — two hooks before, one after, and the surviving machine still delivers while the closed one goes quiet. Plus `_Idempotent`, `_MachineStaysUsable`, `_BeforeSubscribe`, `_RegistrarWithoutRemoveHook`, `_HookRemovalFails`, `_ToleratesAlreadyRemovedHook`, `_ConcurrentCalls`, `_RacingSubscribe` (200 iterations), `_FromWithinAHook`, and `TestReadme_EndingASubscription`.

## Note on scope

This PR also carries the "New in v2.6" release-note callout in `docs/v2-upgrade.md`, which summarises the rename (#81), duplicate rejection (#85) and nil-channel guard (#86) alongside `Close`. It's a release note for the whole set, kept in one place rather than fragmented across eight PRs — flagging it so it isn't mistaken for scope creep.

## API footprint of the whole stack

Relative to `main`, the eight PRs add exactly **four** exported identifiers: `Machine.Subscribe`, `Machine.Close`, `fsm.ErrMachineClosed`, and `broadcast.Manager.UnsubscribeAll` (needed cross-package by `Close`, and useful on its own for direct `Manager` users). Every other candidate — a `Manager.Subscribe` rename, six new error sentinels, and a `HookRemover` interface — was cut after review; the underlying fixes are unchanged, they just wrap existing sentinels or return plain errors.

---

#80 has been closed unmerged, superseded by this stack. The eight PRs together carry every fix from it, plus three defect fixes found while splitting, minus the API surface described above.

https://claude.ai/code/session_01WMFFnBa2iXgQ8ZqMjfYREP

