### PR TITLE
ci: run Go checks on pull requests to any base branch

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,8 +3,13 @@ name: Go
 on:
   push:
     branches: ["main"]
+  # Deliberately unfiltered: run on pull requests targeting ANY base branch, not
+  # just main. A stacked pull request targets its predecessor rather than main,
+  # so a "branches: [main]" filter skipped it entirely — and GitHub reports "no
+  # checks reported", which reads as green when it actually means unverified.
+  # Pushes stay filtered to main so branch pushes are covered once, by the
+  # pull_request event, rather than running twice.
   pull_request:
-    branches: ["main"]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Problem

`.github/workflows/go.yml` filtered its `pull_request` trigger to `main`:

```yaml
pull_request:
  branches: ["main"]
```

A pull request whose base is anything **other than** `main` therefore never ran CI at all.

This isn't hypothetical — it's live right now. Stack #89 (#81–#88) has eight PRs; only #81 targets `main`, so it's the only one that ran CI. The other seven report:

```
no checks reported on the 'pr/02-hooks-registration-defects' branch
```

That's the dangerous part: **"no checks reported" reads as green when it actually means unverified.** There's no failing indicator to notice. Any long-lived integration branch has the same hole.

## How this fixes it

Drops the `branches` filter from `pull_request`, so every PR is tested regardless of base.

The `push` trigger stays filtered to `main` deliberately. Branch pushes are already covered once by the `pull_request` event; removing the filter there too would run the whole suite twice for every push to an open PR.

```yaml
on:
  push:
    branches: ["main"]     # unchanged
  pull_request:            # now unfiltered
```

## Verification

Validated by parsing the workflow: `pull_request` resolves to unfiltered, `push` still `{branches: [main]}`, and all 7 job steps are intact. The job body is untouched — this changes only when the workflow fires, never what it runs.

The real proof is this PR itself, plus #82–#88 picking up checks once this lands.

## Not included

`sonarqube.yml` and `dependency-review.yml` carry the same `branches: ["main"]` filter. I've left them alone since coverage reporting and dependency review are arguably fine to run only against `main` — say the word if you'd rather they match.

https://claude.ai/code/session_01WMFFnBa2iXgQ8ZqMjfYREP